### PR TITLE
Fix code expression buttons

### DIFF
--- a/packages/style-material/src/atoms/button/_base.css
+++ b/packages/style-material/src/atoms/button/_base.css
@@ -1,6 +1,7 @@
 a.button,
 button {
   @apply inline-block px-4 py-2 m-0 text-base font-bold leading-none no-underline whitespace-no-wrap border-none rounded font-body;
+  background-image: none;
   transition: color 120ms ease-out, background-color 120ms ease-out;
 
   &.secondary {

--- a/packages/style-material/src/atoms/tooltip.css
+++ b/packages/style-material/src/atoms/tooltip.css
@@ -1,4 +1,4 @@
 :host,
 stencila-tooltip-element {
-  @apply z-50 inline-block px-2 py-1 text-xs whitespace-no-wrap rounded shadow bg-neutral-700 text-stock font-body;
+  @apply z-50 inline-block w-auto px-2 py-1 text-xs whitespace-no-wrap rounded shadow bg-neutral-700 text-stock font-body;
 }

--- a/packages/style-stencila/src/atoms/button/_base.css
+++ b/packages/style-stencila/src/atoms/button/_base.css
@@ -1,6 +1,7 @@
 a.button,
 button {
-  @apply inline-block px-4 py-2 m-0 text-base leading-none no-underline whitespace-no-wrap border-none font-display font-semibold;
+  @apply inline-block px-4 py-2 m-0 text-base font-semibold leading-none no-underline whitespace-no-wrap border-none font-display;
+  background-image: none;
   transition: color 120ms ease-out, background-color 120ms ease-out;
 
   &.xsmall,

--- a/packages/style-stencila/src/atoms/tooltip.css
+++ b/packages/style-stencila/src/atoms/tooltip.css
@@ -1,4 +1,4 @@
 :host,
 stencila-tooltip-element {
-  @apply z-50 px-2 py-1 text-xs shadow rounded-md bg-neutral-900 text-stock font-body;
+  @apply z-50 w-auto px-2 py-1 text-xs shadow rounded-md bg-neutral-900 text-stock font-body;
 }

--- a/packages/style-stencila/src/molecules/codeExpression.css
+++ b/packages/style-stencila/src/molecules/codeExpression.css
@@ -66,17 +66,9 @@ stencila-code-expression {
     @apply inline-flex items-stretch self-start overflow-hidden cursor-default transition ease-out duration-150;
     transition-property: padding, width, max-width;
 
-    &[icon='eye'] {
-      @apply w-0;
+    &.sourceToggle {
+      @apply inline-block w-0;
     }
-  }
-
-  .extraActions {
-    @apply inline-flex;
-  }
-
-  .extraActions stencila-button {
-    @apply inline-block w-0 max-w-0;
   }
 
   &.isOutputEmpty {
@@ -90,9 +82,8 @@ stencila-code-expression {
   &:focus,
   &:focus-within,
   &:hover {
-    .actions stencila-button[icon='eye'],
-    .extraActions stencila-button {
-      @apply w-8 max-w-full;
+    .actions stencila-button.sourceToggle {
+      @apply inline-flex w-8 max-w-full;
     }
   }
 }


### PR DESCRIPTION
- Fixes an empty space being shown for CodeExpression component when the Source Code 
![Screenshot 2020-08-05 at 16 52 58@2x](https://user-images.githubusercontent.com/1646307/89462994-3ecf3d00-d73c-11ea-8c8e-d4f5debf8811.png)

- Fix Toolbar buttons having an underline in the Tufte Thema theme
![Screenshot 2020-08-05 at 16 50 54@2x](https://user-images.githubusercontent.com/1646307/89463042-53abd080-d73c-11ea-81b6-922d8cfc4e79.png)

- Fix extra wide tooltips in Wilmore Thema theme
<img width="402" alt="Screenshot 2020-08-05 at 16 55 02@2x" src="https://user-images.githubusercontent.com/1646307/89463101-6de5ae80-d73c-11ea-9deb-d8035877ca66.png">

