### PR TITLE
Fix CodeExpression execution & misc visual refinements

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -167,6 +167,9 @@ export namespace Components {
         "table": Datatable;
     }
     interface StencilaDetails {
+        /**
+          * Determines whether the contents are visible or not
+         */
         "open": boolean;
     }
     interface StencilaEditor {
@@ -681,6 +684,9 @@ declare namespace LocalJSX {
         "table"?: Datatable;
     }
     interface StencilaDetails {
+        /**
+          * Determines whether the contents are visible or not
+         */
         "open"?: boolean;
     }
     interface StencilaEditor {

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -159,6 +159,10 @@ export namespace Components {
           * Returns the `CodeExpression` node with the updated `text` contents from the editor.
          */
         "getContents": () => Promise<CodeExpression>;
+        /**
+          * Programming language of the CodeExpression
+         */
+        "programmingLanguage": string;
     }
     interface StencilaDataTable {
         /**
@@ -676,6 +680,10 @@ declare namespace LocalJSX {
         "executeHandler"?: (
     codeExpression: CodeExpression
   ) => Promise<CodeExpression>;
+        /**
+          * Programming language of the CodeExpression
+         */
+        "programmingLanguage"?: string;
     }
     interface StencilaDataTable {
         /**

--- a/packages/components/src/components/codeExpression/codeExpression.tsx
+++ b/packages/components/src/components/codeExpression/codeExpression.tsx
@@ -38,6 +38,12 @@ export class CodeExpressionComponent implements CodeComponent<CodeExpression> {
     codeExpression: CodeExpression
   ) => Promise<CodeExpression>
 
+  /**
+   * Programming language of the CodeExpression
+   */
+  @Prop()
+  public programmingLanguage: string
+
   @State() output: CodeExpression['output']
 
   @State() codeErrors: CodeExpression['errors']
@@ -67,6 +73,7 @@ export class CodeExpressionComponent implements CodeComponent<CodeExpression> {
       codeExpression({
         text: this.getTextSlotContents(),
         output: this.getOutputSlotContents(),
+        programmingLanguage: this.programmingLanguage,
       })
     )
   }

--- a/packages/components/src/components/codeExpression/readme.md
+++ b/packages/components/src/components/codeExpression/readme.md
@@ -5,9 +5,10 @@
 
 ## Properties
 
-| Property         | Attribute | Description                                                                                                      | Type                                                                         | Default     |
-| ---------------- | --------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------- |
-| `executeHandler` | --        | A callback function to be called with the value of the `CodeExpression` node when execting the `CodeExpression`. | `((codeExpression: CodeExpression) => Promise<CodeExpression>) \| undefined` | `undefined` |
+| Property              | Attribute              | Description                                                                                                      | Type                                                                         | Default     |
+| --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------- |
+| `executeHandler`      | --                     | A callback function to be called with the value of the `CodeExpression` node when execting the `CodeExpression`. | `((codeExpression: CodeExpression) => Promise<CodeExpression>) \| undefined` | `undefined` |
+| `programmingLanguage` | `programming-language` | Programming language of the CodeExpression                                                                       | `string`                                                                     | `undefined` |
 
 
 ## Methods

--- a/packages/components/src/components/details/details.tsx
+++ b/packages/components/src/components/details/details.tsx
@@ -11,7 +11,7 @@ import { Component, h, Prop, State, Host } from '@stencil/core'
 export class Details {
   public static readonly elementName = 'stencila-details'
 
-  /*
+  /**
    * Determines whether the contents are visible or not
    */
   @Prop() open = false

--- a/packages/components/src/components/details/readme.md
+++ b/packages/components/src/components/details/readme.md
@@ -5,9 +5,9 @@
 
 ## Properties
 
-| Property | Attribute | Description | Type      | Default |
-| -------- | --------- | ----------- | --------- | ------- |
-| `open`   | `open`    |             | `boolean` | `false` |
+| Property | Attribute | Description                                        | Type      | Default |
+| -------- | --------- | -------------------------------------------------- | --------- | ------- |
+| `open`   | `open`    | Determines whether the contents are visible or not | `boolean` | `false` |
 
 
 ## Dependencies

--- a/packages/components/src/components/error/error.tsx
+++ b/packages/components/src/components/error/error.tsx
@@ -36,7 +36,7 @@ export class Error {
 
         {this.hasStacktrace && (
           <stencila-details>
-            <span slot="summary">Vew the stacktrace</span>
+            <span slot="summary">View the stacktrace</span>
             <slot name="stacktrace" />
           </stencila-details>
         )}

--- a/packages/components/src/components/executableDocumentToolbar/executableDocumentToolbar.tsx
+++ b/packages/components/src/components/executableDocumentToolbar/executableDocumentToolbar.tsx
@@ -50,7 +50,6 @@ type OnReject = (a: JobError) => void
     default: 'executableDocumentToolbar.css',
     material: 'executableDocumentToolbar.css',
   },
-  scoped: true,
 })
 export class StencilaExecutableDocumentToolbar implements ComponentInterface {
   private jobPoller: number | undefined = undefined
@@ -236,7 +235,9 @@ export class StencilaExecutableDocumentToolbar implements ComponentInterface {
         ...(code.errors ?? []),
         codeError({
           errorType: 'error',
-          errorMessage: `Could not run ${code.type}`,
+          errorMessage: `Could not run ${
+            code.type === 'CodeChunk' ? 'code chunk' : 'code expression'
+          }`,
           stackTrace: stackTrace,
         }),
       ],

--- a/packages/components/src/components/executableDocumentToolbar/executableDocumentToolbar.tsx
+++ b/packages/components/src/components/executableDocumentToolbar/executableDocumentToolbar.tsx
@@ -292,7 +292,7 @@ export class StencilaExecutableDocumentToolbar implements ComponentInterface {
                 DE.isPending(this.session) || DE.isRefresh(this.session)
               }
             >
-              Run Document
+              Run<span class="hidden-sm"> Document</span>
             </stencila-button>
           </span>
 

--- a/packages/style-stencila/src/objects/executableToolbar.css
+++ b/packages/style-stencila/src/objects/executableToolbar.css
@@ -13,24 +13,24 @@ stencila-executable-document-toolbar {
       @apply mt-12;
     }
   }
-}
 
-.executableDocumentStatus {
-  @apply text-sm leading-none text-key;
+  .executableDocumentStatus {
+    @apply text-sm leading-none text-key;
 
-  &.success {
-    @apply text-success-700;
-  }
+    &.success {
+      @apply text-success-700;
+    }
 
-  &.danger {
-    @apply text-danger-500;
-  }
+    &.danger {
+      @apply text-danger-500;
+    }
 
-  stencila-icon {
-    @apply mr-1;
-  }
+    stencila-icon {
+      @apply mr-1;
+    }
 
-  stencila-tooltip {
-    cursor: help;
+    stencila-tooltip {
+      cursor: help;
+    }
   }
 }

--- a/packages/style-stencila/src/objects/executableToolbar.css
+++ b/packages/style-stencila/src/objects/executableToolbar.css
@@ -14,6 +14,14 @@ stencila-executable-document-toolbar {
     }
   }
 
+  .hidden-sm {
+    @apply hidden;
+
+    @screen sm {
+      @apply inline;
+    }
+  }
+
   .executableDocumentStatus {
     @apply text-sm leading-none text-key;
 

--- a/stories/molecules/codeExpression/codeExpression.stories.js
+++ b/stories/molecules/codeExpression/codeExpression.stories.js
@@ -5,16 +5,22 @@ export default {
   component: 'stencila-code-expression',
 }
 
+const handler = console.log
+
 export const codeExpression = () => html`
   <div>
     <stencila-code-expression
-      data-collapsed="false"
-      itemtype="stencila:CodeChunk"
+      programming-language="r"
+      itemscope=""
+      itemtype="http://schema.stenci.la/CodeExpression"
+      .executeHandler=${handler}
     >
-      <code slot="text">x * y</code>
-      <output slot="output">
-        Reaaaaalllyyyyyyyy loooongggggggggggggggggggg output
-      </output>
+      <code class="r" slot="text"
+        >length(subset(data2, Lot==1 &amp; Time==0)$value)</code
+      >
+      <output slot="output"
+        ><span data-itemtype="http://schema.org/Number">3</span></output
+      >
     </stencila-code-expression>
   </div>
 `


### PR DESCRIPTION
- fix(CodeExpression): Pass language prop to execution handler (close #38)
- refactor(Exec Toolbar): Remove CSS scoping for to fix sibling element margins
- fix(Exec Toolbar): Give status text more room on small screens
- docs(Details): Fix JSDoc string
- fix(Error): Fix typo in default message