### PR TITLE
feat(Exec Toolbar): Add execution progress indicator

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1512,14 +1512,6 @@
         "@stencila/brand": "0.5.1"
       }
     },
-    "@stencila/style-stencila": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.16.4.tgz",
-      "integrity": "sha512-nXQurEPZboEPzd/XJlMzP95NwrsQrBTTp2wa+vJYErMrZQvqG0ow72KyouT3o36dbvZwnlzeaJt56KeEcmTt6g==",
-      "requires": {
-        "@stencila/brand": "0.5.1"
-      }
-    },
     "@types/babel__core": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
@@ -1633,6 +1625,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/pluralize": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
+      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
       "dev": true
     },
     "@types/prettier": {
@@ -8752,6 +8750,11 @@
           "dev": true
         }
       }
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,6 +35,7 @@
     "@stencila/schema": "0.43.3",
     "@types/feather-icons": "4.7.0",
     "@types/jest": "26.0.9",
+    "@types/pluralize": "0.0.29",
     "@types/puppeteer": "3.0.1",
     "@types/webfontloader": "1.6.32",
     "chokidar-cli": "2.1.0",
@@ -55,6 +56,7 @@
     "@stencila/style-stencila": "0.17.0",
     "animate-presence": "^0.2.1",
     "feather-icons": "^4.28.0",
+    "pluralize": "^8.0.0",
     "tocbot": "^4.12.0",
     "webfontloader": "^1.6.28",
     "wretch": "^1.7.2"

--- a/packages/components/src/components/executableDocumentToolbar/executableDocumentToolbar.tsx
+++ b/packages/components/src/components/executableDocumentToolbar/executableDocumentToolbar.tsx
@@ -16,6 +16,7 @@ import {
 } from '@stencila/schema'
 import { array as A, option as O } from 'fp-ts'
 import { pipe } from 'fp-ts/lib/function'
+import pluralize from 'pluralize'
 import {
   toastController,
   ToastPositions,
@@ -60,7 +61,6 @@ export class StencilaExecutableDocumentToolbar implements ComponentInterface {
 
   private jobUrl: string | undefined
 
-  private codeCount: number
   private activeNodeIndex?: number
 
   /**
@@ -93,6 +93,9 @@ export class StencilaExecutableDocumentToolbar implements ComponentInterface {
 
   @State()
   executor: null | Executor = null
+
+  @State()
+  private codeCount = 0
 
   @State()
   statusMessage = ''
@@ -282,7 +285,10 @@ export class StencilaExecutableDocumentToolbar implements ComponentInterface {
 
       for (const node of this.codeNodeSelector()) {
         this.activeNodeIndex = idx
-        this.statusMessage = `${++idx} of ${this.codeCount}`
+        this.statusMessage = `${++idx} of ${this.codeCount} code ${pluralize(
+          'node',
+          this.codeCount
+        )}`
 
         const res = await node.execute()
         results.push(res)
@@ -297,7 +303,7 @@ export class StencilaExecutableDocumentToolbar implements ComponentInterface {
     })
   }
 
-  componentDidLoad(): void {
+  componentWillLoad(): void {
     const codeNodes = this.codeNodeSelector()
     this.codeCount = codeNodes.length
     codeNodes.map((code) => {
@@ -343,6 +349,12 @@ export class StencilaExecutableDocumentToolbar implements ComponentInterface {
               icon="play"
               size="small"
               clickHandlerProp={this.runAll}
+              disabled={this.codeCount <= 0}
+              tooltip={
+                this.codeCount <= 0
+                  ? 'No code nodes in the document to execute'
+                  : undefined
+              }
               isLoading={
                 DE.isPending(this.session) || DE.isRefresh(this.session)
               }

--- a/packages/components/src/components/executableDocumentToolbar/readme.md
+++ b/packages/components/src/components/executableDocumentToolbar/readme.md
@@ -25,25 +25,25 @@
 
 ### Depends on
 
+- [stencila-tooltip](../tooltip)
+- [stencila-icon](../icon)
 - [stencila-toolbar](../toolbar)
 - [stencila-button](../button)
 - animate-presence
 - [stencila-toast](../toast)
-- [stencila-icon](../icon)
-- [stencila-tooltip](../tooltip)
 
 ### Graph
 ```mermaid
 graph TD;
+  stencila-executable-document-toolbar --> stencila-tooltip
+  stencila-executable-document-toolbar --> stencila-icon
   stencila-executable-document-toolbar --> stencila-toolbar
   stencila-executable-document-toolbar --> stencila-button
   stencila-executable-document-toolbar --> animate-presence
   stencila-executable-document-toolbar --> stencila-toast
-  stencila-executable-document-toolbar --> stencila-icon
-  stencila-executable-document-toolbar --> stencila-tooltip
+  stencila-tooltip --> stencila-tooltip-element
   stencila-button --> stencila-icon
   stencila-button --> stencila-tooltip
-  stencila-tooltip --> stencila-tooltip-element
   stencila-toast --> animate-presence
   stencila-toast --> stencila-toast
   style stencila-executable-document-toolbar fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/components/src/components/executableDocumentToolbar/sessionStatus.tsx
+++ b/packages/components/src/components/executableDocumentToolbar/sessionStatus.tsx
@@ -1,11 +1,13 @@
 import { datumEither as DE } from '@nll/datum'
-import { FunctionalComponent, h } from '@stencil/core'
+import { FunctionalComponent, h, VNode } from '@stencil/core'
+import { array as A } from 'fp-ts'
 import { pipe } from 'fp-ts/lib/function'
 import { isErrorGuard, JobDatum, JobError, SessionDatum } from './executa'
 
 interface HelloProps {
   session: SessionDatum
   job: JobDatum
+  children?: VNode | VNode[]
 }
 
 const jobErrorMessage = (jobError: JobError): string =>
@@ -26,10 +28,10 @@ const jobStatusString = (jobObject: JobDatum): string =>
     )
   )
 
-export const SessionStatus: FunctionalComponent<HelloProps> = ({
-  session,
-  job,
-}) => (
+export const SessionStatus: FunctionalComponent<HelloProps> = (
+  { session, job },
+  children
+) => (
   <span
     class={{
       executableDocumentStatus: true,
@@ -44,30 +46,37 @@ export const SessionStatus: FunctionalComponent<HelloProps> = ({
         () => (
           <span>
             <stencila-icon icon="loader-2"></stencila-icon>
-            {jobStatusString(job)}
+            <span>{jobStatusString(job)}</span>
           </span>
         ),
         (refreshingErroredJob) => (
           <span>
             <stencila-icon icon="loader-2"></stencila-icon>
-            {jobErrorMessage(refreshingErroredJob)}
+            <span>{jobErrorMessage(refreshingErroredJob)}</span>
           </span>
         ),
         (refreshingSession) => (
           <span>
-            <stencila-icon icon="loader-2"></stencila-icon>
-            {refreshingSession.status}
+            {A.isEmpty(children) ? (
+              [
+                <stencila-icon icon="loader-2"></stencila-icon>,
+                refreshingSession.status,
+              ]
+            ) : (
+              <span>{children}</span>
+            )}
           </span>
         ),
         (err) => (
           <span>
             <stencila-icon icon="error-warning"></stencila-icon>
-            {jobErrorMessage(err)}
+            <span>{jobErrorMessage(err)}</span>
           </span>
         ),
         () => (
           <stencila-tooltip text="Compute session is active">
             <stencila-icon icon="pulse"></stencila-icon>
+            {A.isEmpty(children) ? null : <span>{children}</span>}
           </stencila-tooltip>
         )
       )

--- a/packages/style-stencila/src/objects/executableToolbar.css
+++ b/packages/style-stencila/src/objects/executableToolbar.css
@@ -40,5 +40,9 @@ stencila-executable-document-toolbar {
     stencila-tooltip {
       cursor: help;
     }
+
+    span {
+      @apply align-middle;
+    }
   }
 }


### PR DESCRIPTION
In using the executable documents of any moderate length, we found a need to navigate to the code node being currently executed, especially if the process was taking some time. This PR adds a progress indicator, which when clicked scrolls the element into view.
The updating message also reassures the user that progress is being made, and that the computation hasn't stalled.
I decided to keep the UI affordances subtle as I deemed this to be a non-essential interaction.

Would appreciate feedback if you have any thoughts @chugginselifesciences or @gmaciocci.
Otherwise I'll be merging this sometime tomorrow.

![Screenshot 2020-08-19 at 12 45 04](https://user-images.githubusercontent.com/1646307/90666700-c7a9a680-e21b-11ea-89c5-00f56bd21b94.gif)

**On a larger document:**

![Screenshot 2020-08-19 at 12 51 43](https://user-images.githubusercontent.com/1646307/90666735-d1cba500-e21b-11ea-9fc5-6e04922e2adc.gif)
