### PR TITLE
fix(Editor): Augment default language completion w/ words from document

### DIFF
--- a/packages/components/src/components/editor/editor.tsx
+++ b/packages/components/src/components/editor/editor.tsx
@@ -211,7 +211,8 @@ export class Editor {
 
     const extensions: Extension[] = [
       history(),
-      autocompletion({ override: [completeAnyWord] }),
+      autocompletion(),
+      EditorState.languageData.of(() => [{ autocomplete: completeAnyWord }]),
       bracketMatching(),
       closeBrackets(),
       Prec.fallback(defaultHighlightStyle),


### PR DESCRIPTION
This change allows the default language provided autocompletion suggestions to be extended with words found in the document. Before the list of words from the document would override any language provided suggestions.