### PR TITLE
Editor: Ensure dependencies are installed in consuming projects

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -479,7 +479,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.17.1.tgz",
       "integrity": "sha512-JafuzWLKuUfKh8rF2VYgUx+fzD4upFxV9kJuIUyv94/S9RcdrDPRU46AmfSpdumY6A9F2qQuTEc5ZLaK3g0iaw==",
-      "dev": true,
       "requires": {
         "@codemirror/stream-parser": "^0.17.0"
       }
@@ -515,7 +514,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.17.1.tgz",
       "integrity": "sha512-toCFLbPzzXNxCjyeNtu/s5Me1xDFQp6qCS4CNfslnW3iAg86M7W4v8SJocmVO3ALAr/6Ci/ECSIN7jsGZcAitw==",
-      "dev": true,
       "requires": {
         "@codemirror/highlight": "^0.17.0",
         "@codemirror/language": "^0.17.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,8 +31,6 @@
     "prepublishOnly": "node ./scripts/prepare.mjs && npm run build"
   },
   "devDependencies": {
-    "@codemirror/legacy-modes": "0.17.1",
-    "@codemirror/stream-parser": "0.17.1",
     "@fullhuman/postcss-purgecss": "2.3.0",
     "@stencil/core": "2.3.0",
     "@stencil/postcss": "1.0.1",
@@ -62,7 +60,9 @@
     "@codemirror/highlight": "^0.17.1",
     "@codemirror/history": "^0.17.1",
     "@codemirror/lang-python": "^0.17.2",
+    "@codemirror/legacy-modes": "^0.17.1",
     "@codemirror/state": "^0.17.1",
+    "@codemirror/stream-parser": "^0.17.1",
     "@codemirror/view": "^0.17.5",
     "@nll/datum": "^3.3.0",
     "@popperjs/core": "^2.5.4",


### PR DESCRIPTION
With the [latest changes](https://github.com/stencila/designa/pull/145) some of the dependencies were listed under `devDependcies`, meaning that they weren't installed when the component library was used in another project.

This PR fixes the issue.