### PR TITLE
docs(README): Add NPM badges for each package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ We aim to maintain browser support for popular browsers according to [Browsersli
 
 ## 📦 Packages
 
-This repository is a [monorepo](https://en.wikipedia.org/wiki/Monorepo), and contains the following packages:
+This repository is a [monorepo](https://en.wikipedia.org/wiki/Monorepo), and contains the following packages.
 
-- [components](./packages/components): Web Components built using [StencilJS](https://stenciljs.com), styled using the `style-*` packages listed below.
-- [style-stencila](./packages/style-stencila): CSS for styling semantic HTML markup in Stencila's own visual language.
-- [style-material](./packages/style-material): CSS for styling semantic HTML markup in Google's Material Design visual language.
-- [brand](./packages/brand): Stencila branding elements such as fonts, logos, and illustrations.
+|Name                                        | Description                                                                                                      | NPM
+|--------------------------------------------|------------------------------------------------------------------------------------------------------------------|-----
+[components](./packages/components)          | Web Components built using [StencilJS](https://stenciljs.com), styled using the `style-*` packages listed below. | [![NPM](https://img.shields.io/npm/v/@stencila/components.svg?style=flat)](https://www.npmjs.com/package/@stencila/components)
+[style-stencila](./packages/style-stencila)  | CSS for styling semantic HTML markup in Stencila's own visual language.                                          | [![NPM](https://img.shields.io/npm/v/@stencila/style-stencila.svg?style=flat)](https://www.npmjs.com/package/@stencila/style-stencila)
+[style-material](./packages/style-material)  | CSS for styling semantic HTML markup in Google's Material Design visual language.                                | [![NPM](https://img.shields.io/npm/v/@stencila/style-material.svg?style=flat)](https://www.npmjs.com/package/@stencila/style-material)
+[brand](./packages/brand)                    | Stencila branding elements such as fonts, logos, and illustrations.                                              | [![NPM](https://img.shields.io/npm/v/@stencila/brand.svg?style=flat)](https://www.npmjs.com/package/@stencila/brand)
 
 ## 📜 Documentation
 


### PR DESCRIPTION
I went looking for the latest version of `@stencila/components`, came here first thinking I would use latest GitHub release as I do for other repos (but of course this is a monorepo so different releases for different packages). Anyway, this just makes that search for version numbers a little more convienient.