### PR TITLE
Fix code expression output rendering

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -147,7 +147,7 @@ export namespace Components {
          */
         "execute": () => Promise<CodeExpression>;
         /**
-          * A callback function to be called with the value of the `CodeExpression` node when execting the `CodeExpression`.
+          * A callback function to be called with the value of the `CodeExpression` node when executing the `CodeExpression`.
          */
         "executeHandler"?: (
     codeExpression: CodeExpression
@@ -664,7 +664,7 @@ declare namespace LocalJSX {
     }
     interface StencilaCodeExpression {
         /**
-          * A callback function to be called with the value of the `CodeExpression` node when execting the `CodeExpression`.
+          * A callback function to be called with the value of the `CodeExpression` node when executing the `CodeExpression`.
          */
         "executeHandler"?: (
     codeExpression: CodeExpression

--- a/packages/components/src/components/codeExpression/readme.md
+++ b/packages/components/src/components/codeExpression/readme.md
@@ -5,10 +5,10 @@
 
 ## Properties
 
-| Property              | Attribute              | Description                                                                                                      | Type                                                                         | Default     |
-| --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------- |
-| `executeHandler`      | --                     | A callback function to be called with the value of the `CodeExpression` node when execting the `CodeExpression`. | `((codeExpression: CodeExpression) => Promise<CodeExpression>) \| undefined` | `undefined` |
-| `programmingLanguage` | `programming-language` | Programming language of the CodeExpression                                                                       | `string`                                                                     | `undefined` |
+| Property              | Attribute              | Description                                                                                                       | Type                                                                         | Default     |
+| --------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------- |
+| `executeHandler`      | --                     | A callback function to be called with the value of the `CodeExpression` node when executing the `CodeExpression`. | `((codeExpression: CodeExpression) => Promise<CodeExpression>) \| undefined` | `undefined` |
+| `programmingLanguage` | `programming-language` | Programming language of the CodeExpression                                                                        | `string`                                                                     | `undefined` |
 
 
 ## Methods

--- a/packages/components/src/components/nodeList/nodeRenderer.tsx
+++ b/packages/components/src/components/nodeList/nodeRenderer.tsx
@@ -1,11 +1,15 @@
 import { FunctionalComponent, h, VNode } from '@stencil/core'
 import { isA, isCode, isPrimitive, Node } from '@stencila/schema'
 
-const schemNodeHTMLRegExp = /itemtype=".+?"/
+const schemaNodeHTMLRegExp = /itemtype=".+?"/
 
 const renderNode = (node: Node): VNode => {
-  if (typeof node === 'string' && schemNodeHTMLRegExp.test(node)) {
+  if (typeof node === 'string' && schemaNodeHTMLRegExp.test(node)) {
     return <span innerHTML={node}></span>
+  }
+
+  if (node instanceof HTMLElement) {
+    return <span innerHTML={node.outerHTML}></span>
   }
 
   if (isPrimitive(node)) {

--- a/packages/style-stencila/src/molecules/codeExpression.css
+++ b/packages/style-stencila/src/molecules/codeExpression.css
@@ -54,7 +54,7 @@ stencila-code-expression {
 
   .output {
     & > * {
-      @apply inline-block p-0 m-0 font-mono text-xs border-none bg-stock text-key;
+      @apply inline-block p-0 m-0 font-mono text-xs border-none bg-stock text-key whitespace-normal;
     }
   }
 

--- a/stories/molecules/codeExpression/codeExpression.stories.js
+++ b/stories/molecules/codeExpression/codeExpression.stories.js
@@ -78,8 +78,8 @@ export const codeExpressionWithAnImageOutput = () => html`
     >
       <code slot="text">x * y - 128 * (212 - 2)</code>
       <output slot="output"
-        ><img src="https://via.placeholder.com/150x200"</output
-      > </stencila-code-expression
+        ><img src="https://via.placeholder.com/150x200"
+      /></output> </stencila-code-expression
     >.
   </p>
 `


### PR DESCRIPTION
- Refines the handling of whitespaces and newlines in code expression outputs to make them fit better with surrounding text content 
- Fixes a regression with rendering of image and other HTML elements in the output section