### PR TITLE
Code chunk layout toggle

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -644,6 +644,10 @@ declare namespace LocalJSX {
          */
         "onSetAllCodeVisibility"?: (event: CustomEvent<any>) => void;
         /**
+          * Trigger a global DOM event to set the layout of all `CodeChunk` component. Can be set to either show the editor and outputs side by side or stacked vertically.
+         */
+        "onSetEditorLayout"?: (event: CustomEvent<any>) => void;
+        /**
           * Programming language of the CodeChunk
          */
         "programmingLanguageProp"?: string;

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -102,17 +102,13 @@ export namespace Components {
          */
         "execute": () => Promise<CodeChunk>;
         /**
-          * A callback function to be called with the value of the `CodeChunk` node when execting the `CodeChunk`.
+          * A callback function to be called with the value of the `CodeChunk` node when executing the `CodeChunk`.
          */
         "executeHandler"?: (codeChunk: CodeChunk) => Promise<CodeChunk>;
         /**
           * Returns the `CodeChunk` node with the updated `text` content from the editor.
          */
         "getContents": () => Promise<CodeChunk>;
-        /**
-          * @deprecated Use `isCodeVisible` prop (`is-code-visible` attribute) instead Whether the code section is visible or not
-         */
-        "isCodeCollapsed": boolean;
         /**
           * Whether the code section is visible or not
          */
@@ -623,13 +619,9 @@ declare namespace LocalJSX {
          */
         "autofocus"?: boolean;
         /**
-          * A callback function to be called with the value of the `CodeChunk` node when execting the `CodeChunk`.
+          * A callback function to be called with the value of the `CodeChunk` node when executing the `CodeChunk`.
          */
         "executeHandler"?: (codeChunk: CodeChunk) => Promise<CodeChunk>;
-        /**
-          * @deprecated Use `isCodeVisible` prop (`is-code-visible` attribute) instead Whether the code section is visible or not
-         */
-        "isCodeCollapsed"?: boolean;
         /**
           * Whether the code section is visible or not
          */

--- a/packages/components/src/components/actionMenu/actionMenu.tsx
+++ b/packages/components/src/components/actionMenu/actionMenu.tsx
@@ -43,7 +43,9 @@ export class ActionMenu {
   private calculateWidth = () => {
     if (this.actionContainerRef !== null && this.isTransitioning === false) {
       this.width = 'auto'
+
       const width = this.actionContainerRef.getBoundingClientRect().width
+
       this.width = `${width}px`
     }
   }
@@ -91,12 +93,26 @@ export class ActionMenu {
   public render() {
     return (
       <nav>
+        <span class="persistentActions">
+          <slot name={slots.persistentActions} />
+        </span>
+
         <span
           class={{
             secondaryActions: true,
             hidden: this.hasSecondaryActions,
           }}
         >
+          <stencila-button
+            onClick={this.toggleActionMenu}
+            icon="more"
+            color="key"
+            minimal={true}
+            size="xsmall"
+            iconOnly={true}
+            ariaLabel="Toggle Action Menu"
+          ></stencila-button>
+
           <span
             class={{
               actionContainer: true,
@@ -107,20 +123,6 @@ export class ActionMenu {
           >
             <slot />
           </span>
-
-          <stencila-button
-            onClick={this.toggleActionMenu}
-            icon="more"
-            color="key"
-            minimal={true}
-            size="xsmall"
-            iconOnly={true}
-            ariaLabel="Toggle Action Menu"
-          ></stencila-button>
-        </span>
-
-        <span class="persistentActions">
-          <slot name={slots.persistentActions} />
         </span>
       </nav>
     )

--- a/packages/components/src/components/codeChunk/codeChunk.tsx
+++ b/packages/components/src/components/codeChunk/codeChunk.tsx
@@ -46,22 +46,13 @@ export class CodeChunkComponent implements CodeComponent<CodeChunk> {
   public programmingLanguageProp: string
 
   /**
-   * @deprecated Use `isCodeVisible` prop (`is-code-visible` attribute) instead
-   * Whether the code section is visible or not
-   */
-  @Prop({
-    attribute: 'data-collapsed',
-  })
-  public isCodeCollapsed = false
-
-  /**
    * Whether the code section is visible or not
    */
   @Prop()
   public isCodeVisible = false
 
   /**
-   * A callback function to be called with the value of the `CodeChunk` node when execting the `CodeChunk`.
+   * A callback function to be called with the value of the `CodeChunk` node when executing the `CodeChunk`.
    */
   @Prop() public executeHandler?: (codeChunk: CodeChunk) => Promise<CodeChunk>
 
@@ -216,8 +207,7 @@ export class CodeChunkComponent implements CodeComponent<CodeChunk> {
   }
 
   private setCodeVisibility = (e: CodeVisibilityEvent): void => {
-    // TODO: Remove usage of `isCodeCollapsed` once prop is fully deprecated.
-    this.isCodeVisibleState = e.detail.isVisible ?? e.detail.isCodeCollapsed
+    this.isCodeVisibleState = e.detail.isVisible
   }
 
   public render(): HTMLElement {

--- a/packages/components/src/components/codeChunk/codeChunk.tsx
+++ b/packages/components/src/components/codeChunk/codeChunk.tsx
@@ -73,6 +73,8 @@ export class CodeChunkComponent implements CodeComponent<CodeChunk> {
 
   @State() executeCodeState: 'INITIAL' | 'PENDING' | 'RESOLVED' = 'INITIAL'
 
+  @State() isStacked = true
+
   @State() outputs: CodeChunk['outputs']
 
   @State() codeErrors: CodeChunk['errors']
@@ -95,6 +97,7 @@ export class CodeChunkComponent implements CodeComponent<CodeChunk> {
   }
 
   private toggleCodeVisibility = (e: MouseEvent): void => {
+    e.preventDefault()
     if (e.shiftKey) {
       this.toggleAllCodeVisibility()
     } else {
@@ -119,6 +122,42 @@ export class CodeChunkComponent implements CodeComponent<CodeChunk> {
 
     this.executeCodeState = 'RESOLVED'
     return node
+  }
+
+  private setEditorLayoutHandler = (isStacked: boolean) => {
+    this.isStacked = isStacked
+  }
+
+  /**
+   * Trigger a global DOM event to set the layout of all `CodeChunk` component.
+   * Can be set to either show the editor and outputs side by side or stacked vertically.
+   */
+  @Event({
+    eventName: 'setEditorLayout',
+  })
+  public setEditorLayout: EventEmitter
+
+  @Listen('setEditorLayout', { target: 'window' })
+  onSetEditorLayout(event: { detail: { isStacked: boolean } }): void {
+    this.setEditorLayoutHandler(event.detail.isStacked)
+  }
+
+  private toggleEditorLayout = (e: MouseEvent) => {
+    e.preventDefault()
+    if (e.shiftKey) {
+      this.setEditorLayout.emit({ isStacked: !this.isStacked })
+    } else {
+      this.setEditorLayoutHandler(!this.isStacked)
+    }
+  }
+
+  componentWillLoad(): void {
+    /** Get rendered width of component to decide whether to stack the editor and outputs or not.
+     * We can’t use media queries as the component is not always full width of the viewport, and depends on the parent element width.
+     */
+    const minWidth = 1200 // A non-scientific value below which the side-by-side layout looks too narrow.
+    console.log(this.el.getBoundingClientRect().width)
+    this.isStacked = this.el.getBoundingClientRect().width < minWidth
   }
 
   componentDidLoad(): void {
@@ -186,9 +225,10 @@ export class CodeChunkComponent implements CodeComponent<CodeChunk> {
       <Host
         class={{
           isCodeVisible: this.isCodeVisibleState,
+          isStacked: this.isStacked,
         }}
       >
-        <stencila-action-menu expandable={true}>
+        <stencila-action-menu>
           {this.executeHandler !== undefined && (
             <stencila-button
               icon="play"
@@ -213,8 +253,26 @@ export class CodeChunkComponent implements CodeComponent<CodeChunk> {
             iconOnly={true}
             size="xsmall"
             slot="persistentActions"
-            tooltip={`${this.isCodeVisibleState ? 'Hide' : 'Show'} Code`}
+            tooltip={`${
+              this.isCodeVisibleState ? 'Hide' : 'Show'
+            } Code\nShift click to set for all code blocks`}
           ></stencila-button>
+
+          {this.isCodeVisibleState && (
+            <stencila-button
+              minimal={true}
+              color="key"
+              class="layoutToggle"
+              onClick={this.toggleEditorLayout}
+              icon={this.isStacked ? 'layout-column' : 'layout-row'}
+              iconOnly={true}
+              size="xsmall"
+              slot="persistentActions"
+              tooltip={`${
+                this.isStacked ? 'Side by side' : 'Stacked'
+              } view\nShift click to set for all code blocks`}
+            ></stencila-button>
+          )}
         </stencila-action-menu>
 
         <div>

--- a/packages/components/src/components/codeChunk/readme.md
+++ b/packages/components/src/components/codeChunk/readme.md
@@ -5,14 +5,13 @@
 
 ## Properties
 
-| Property                  | Attribute                  | Description                                                                                                                                                         | Type                                                          | Default     |
-| ------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ----------- |
-| `autofocus`               | `autofocus`                | Autofocus the editor on page load                                                                                                                                   | `boolean`                                                     | `false`     |
-| `executeHandler`          | --                         | A callback function to be called with the value of the `CodeChunk` node when execting the `CodeChunk`.                                                              | `((codeChunk: CodeChunk) => Promise<CodeChunk>) \| undefined` | `undefined` |
-| `isCodeCollapsed`         | `data-collapsed`           | <span style="color:red">**[DEPRECATED]**</span> Use `isCodeVisible` prop (`is-code-visible` attribute) instead Whether the code section is visible or not<br/><br/> | `boolean`                                                     | `false`     |
-| `isCodeVisible`           | `is-code-visible`          | Whether the code section is visible or not                                                                                                                          | `boolean`                                                     | `false`     |
-| `keymap`                  | --                         | Custom keyboard shortcuts to pass along to CodeMirror                                                                                                               | `KeyBinding[]`                                                | `[]`        |
-| `programmingLanguageProp` | `data-programminglanguage` | Programming language of the CodeChunk                                                                                                                               | `string`                                                      | `undefined` |
+| Property                  | Attribute                  | Description                                                                                             | Type                                                          | Default     |
+| ------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ----------- |
+| `autofocus`               | `autofocus`                | Autofocus the editor on page load                                                                       | `boolean`                                                     | `false`     |
+| `executeHandler`          | --                         | A callback function to be called with the value of the `CodeChunk` node when executing the `CodeChunk`. | `((codeChunk: CodeChunk) => Promise<CodeChunk>) \| undefined` | `undefined` |
+| `isCodeVisible`           | `is-code-visible`          | Whether the code section is visible or not                                                              | `boolean`                                                     | `false`     |
+| `keymap`                  | --                         | Custom keyboard shortcuts to pass along to CodeMirror                                                   | `KeyBinding[]`                                                | `[]`        |
+| `programmingLanguageProp` | `data-programminglanguage` | Programming language of the CodeChunk                                                                   | `string`                                                      | `undefined` |
 
 
 ## Events

--- a/packages/components/src/components/codeChunk/readme.md
+++ b/packages/components/src/components/codeChunk/readme.md
@@ -17,9 +17,10 @@
 
 ## Events
 
-| Event                  | Description                                                                                                                           | Type               |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `setAllCodeVisibility` | Trigger a global DOM event to hide or show all `CodeChunk` and `CodeExpress` component source code, leaving only the results visible. | `CustomEvent<any>` |
+| Event                  | Description                                                                                                                                                     | Type               |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `setAllCodeVisibility` | Trigger a global DOM event to hide or show all `CodeChunk` and `CodeExpress` component source code, leaving only the results visible.                           | `CustomEvent<any>` |
+| `setEditorLayout`      | Trigger a global DOM event to set the layout of all `CodeChunk` component. Can be set to either show the editor and outputs side by side or stacked vertically. | `CustomEvent<any>` |
 
 
 ## Methods

--- a/packages/style-material/src/atoms/tooltip.css
+++ b/packages/style-material/src/atoms/tooltip.css
@@ -1,4 +1,5 @@
 :host,
 stencila-tooltip-element {
   @apply z-50 inline-block w-auto px-2 py-1 text-xs whitespace-no-wrap rounded shadow bg-neutral-700 text-stock font-body;
+  width: auto !important;
 }

--- a/packages/style-stencila/src/atoms/tooltip.css
+++ b/packages/style-stencila/src/atoms/tooltip.css
@@ -1,4 +1,5 @@
 :host,
 stencila-tooltip-element {
   @apply z-50 w-auto px-2 py-1 text-xs shadow rounded-md bg-neutral-900 text-stock font-body;
+  width: auto !important;
 }

--- a/packages/style-stencila/src/molecules/actionMenu.css
+++ b/packages/style-stencila/src/molecules/actionMenu.css
@@ -29,7 +29,8 @@
     }
   }
 
-  stencila-button {
+  stencila-button,
+  ::slotted(stencila-button) {
     @apply inline-block;
   }
 

--- a/packages/style-stencila/src/molecules/codeChunk.css
+++ b/packages/style-stencila/src/molecules/codeChunk.css
@@ -33,6 +33,14 @@ stencila-code-chunk {
     @apply p-2 m-0;
     background-color: var(--background);
   }
+
+  .layoutToggle {
+    @apply hidden;
+
+    @screen lg {
+      @apply inline-block;
+    }
+  }
 }
 
 .editorContainer {
@@ -52,16 +60,16 @@ stencila-code-chunk {
 }
 
 @screen lg {
-  :host > div,
-  stencila-code-chunk > div {
+  :host:not(.isStacked) > div,
+  stencila-code-chunk:not(.isStacked) > div {
     @apply flex flex-row items-stretch w-full;
-  }
 
-  .editorContainer {
-    @apply w-1/2 border-b-0 border-r;
-  }
+    .editorContainer {
+      @apply w-1/2 border-b-0 border-r;
+    }
 
-  stencila-node-list {
-    @apply flex-grow w-1/2;
+    stencila-node-list {
+      @apply flex-grow w-1/2;
+    }
   }
 }

--- a/stories/molecules/codeChunk/codeChunk.stories.js
+++ b/stories/molecules/codeChunk/codeChunk.stories.js
@@ -17,12 +17,17 @@ const executeHandler = (t) =>
   delay(() => console.log(t) || { outputs: [t, t, t] })
 
 export const withExecuteHandler = () => html`
-  <stencila-code-chunk .executeHandler=${executeHandler}>
-    <pre slot="text">print(a)</pre>
-    <figure slot="outputs">
-      <pre><output>10</output></pre>
-    </figure>
-  </stencila-code-chunk>
+  <div style="max-width: 900px">
+    <stencila-code-chunk
+      .executeHandler=${executeHandler}
+      .isCodeVisible=${true}
+    >
+      <pre slot="text">print(a)</pre>
+      <figure slot="outputs">
+        <pre><output>10</output></pre>
+      </figure>
+    </stencila-code-chunk>
+  </div>
 `
 
 export const singleCodeChunk = () => html`


### PR DESCRIPTION
This PR adds logic at the time of `CodeChunk` component load to calculate the rendered width of the editor.
If it's below a certain width, then we vertically stack the editor and outputs.

Previously we were using media queries to do this, but that only takes into account the viewport width and not the parent element width. This was especially noticeable in Thema themes with relatively narrow article widths, or ones which didn't allow the CodeChunk component to break out of the article width constraint.

On mobile breakpoints the layout toggle button is hidden, as the layout is always stacked on narrow breakpoints.

https://user-images.githubusercontent.com/1646307/107988425-fa9bdf80-6f9d-11eb-854b-1b39affe8604.mp4

