### PR TITLE
Editor & Toast component refinements

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@stencila/components",
-      "version": "0.35.1",
+      "version": "0.36.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^0.18.8",
@@ -31,8 +31,8 @@
         "@nll/datum": "^3.5.0",
         "@popperjs/core": "^2.9.2",
         "@stencila/executa": "^1.15.7",
-        "@stencila/style-material": "0.13.3",
-        "@stencila/style-stencila": "0.23.3",
+        "@stencila/style-material": "0.14.0",
+        "@stencila/style-stencila": "0.24.0",
         "animate-presence": "^0.2.1",
         "feather-icons": "^4.28.0",
         "mem": "^8.1.1",
@@ -64,7 +64,7 @@
         "tailwindcss": "2.2.4"
       },
       "peerDependencies": {
-        "@stencila/schema": "^1.0.0"
+        "@stencila/schema": "^1.9.0"
       }
     },
     "../style-material": {
@@ -2063,17 +2063,17 @@
       "integrity": "sha512-4YhRt3dyNSE9cRpDYgDvIR+Rwvo3vC3+2gHRNZhEaAy9q7RX7XNSbi/ZhFiUnv1oDsdE8U32iiTC1V4G49CXdg=="
     },
     "node_modules/@stencila/style-material": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.13.3.tgz",
-      "integrity": "sha512-Ay6Ny0QWecC8e0vj4SBqzeB1NRW3BmIBfH3aIQwFD6/O9JGNt3yZeDFnhydZ4e2EVBiDBG19QjgKaI74Nyt52Q==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.14.0.tgz",
+      "integrity": "sha512-S/sgYDbIlTXaUgVyxdGOa3RPuoaA5cLpT5yzNfC3c6Bt6tlJf/23u0JDWl48EauEGUEzCo0h9aXQdNhLOf9IZw==",
       "dependencies": {
         "@stencila/brand": "0.7.2"
       }
     },
     "node_modules/@stencila/style-stencila": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.23.3.tgz",
-      "integrity": "sha512-Vooh+vjKwL+z0AOmLq97CtZHwXdJnCzAn9vqCncniLKTXGnc6D55hop2MAYtWd2sUOliwz2IwB8gRUrwrFxiog==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.24.0.tgz",
+      "integrity": "sha512-YN005uUDP06jgVtbGMo5v3474pZw/3zqel8SfxOH4Iuu2y4A3O6tdL7KTJOiQUeyHvXTFcVwz3VFkvSEiGEo6Q==",
       "dependencies": {
         "@stencila/brand": "0.7.2"
       }
@@ -14168,17 +14168,17 @@
       "integrity": "sha512-4YhRt3dyNSE9cRpDYgDvIR+Rwvo3vC3+2gHRNZhEaAy9q7RX7XNSbi/ZhFiUnv1oDsdE8U32iiTC1V4G49CXdg=="
     },
     "@stencila/style-material": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.13.3.tgz",
-      "integrity": "sha512-Ay6Ny0QWecC8e0vj4SBqzeB1NRW3BmIBfH3aIQwFD6/O9JGNt3yZeDFnhydZ4e2EVBiDBG19QjgKaI74Nyt52Q==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.14.0.tgz",
+      "integrity": "sha512-S/sgYDbIlTXaUgVyxdGOa3RPuoaA5cLpT5yzNfC3c6Bt6tlJf/23u0JDWl48EauEGUEzCo0h9aXQdNhLOf9IZw==",
       "requires": {
         "@stencila/brand": "0.7.2"
       }
     },
     "@stencila/style-stencila": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.23.3.tgz",
-      "integrity": "sha512-Vooh+vjKwL+z0AOmLq97CtZHwXdJnCzAn9vqCncniLKTXGnc6D55hop2MAYtWd2sUOliwz2IwB8gRUrwrFxiog==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.24.0.tgz",
+      "integrity": "sha512-YN005uUDP06jgVtbGMo5v3474pZw/3zqel8SfxOH4Iuu2y4A3O6tdL7KTJOiQUeyHvXTFcVwz3VFkvSEiGEo6Q==",
       "requires": {
         "@stencila/brand": "0.7.2"
       }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -84,7 +84,7 @@
     "wretch": "^1.7.5"
   },
   "peerDependencies": {
-    "@stencila/schema": "^1.0.0"
+    "@stencila/schema": "^1.9.0"
   },
   "browserslist": [
     "defaults",

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -396,6 +396,12 @@ export namespace Components {
          */
         "type": ToastType;
     }
+    interface StencilaToastContainer {
+        /**
+          * Default position of Toasts on the screen. Can be overridden by individual Toast instances.
+         */
+        "position": ToastPosition;
+    }
     interface StencilaToolbar {
         /**
           * The background fill color of the Navbar
@@ -536,6 +542,12 @@ declare global {
         prototype: HTMLStencilaToastElement;
         new (): HTMLStencilaToastElement;
     };
+    interface HTMLStencilaToastContainerElement extends Components.StencilaToastContainer, HTMLStencilElement {
+    }
+    var HTMLStencilaToastContainerElement: {
+        prototype: HTMLStencilaToastContainerElement;
+        new (): HTMLStencilaToastContainerElement;
+    };
     interface HTMLStencilaToolbarElement extends Components.StencilaToolbar, HTMLStencilElement {
     }
     var HTMLStencilaToolbarElement: {
@@ -575,6 +587,7 @@ declare global {
         "stencila-tab": HTMLStencilaTabElement;
         "stencila-tab-list": HTMLStencilaTabListElement;
         "stencila-toast": HTMLStencilaToastElement;
+        "stencila-toast-container": HTMLStencilaToastContainerElement;
         "stencila-toolbar": HTMLStencilaToolbarElement;
         "stencila-tooltip": HTMLStencilaTooltipElement;
         "stencila-tooltip-element": HTMLStencilaTooltipElementElement;
@@ -940,6 +953,12 @@ declare namespace LocalJSX {
          */
         "type"?: ToastType;
     }
+    interface StencilaToastContainer {
+        /**
+          * Default position of Toasts on the screen. Can be overridden by individual Toast instances.
+         */
+        "position"?: ToastPosition;
+    }
     interface StencilaToolbar {
         /**
           * The background fill color of the Navbar
@@ -979,6 +998,7 @@ declare namespace LocalJSX {
         "stencila-tab": StencilaTab;
         "stencila-tab-list": StencilaTabList;
         "stencila-toast": StencilaToast;
+        "stencila-toast-container": StencilaToastContainer;
         "stencila-toolbar": StencilaToolbar;
         "stencila-tooltip": StencilaTooltip;
         "stencila-tooltip-element": StencilaTooltipElement;
@@ -1008,6 +1028,7 @@ declare module "@stencil/core" {
             "stencila-tab": LocalJSX.StencilaTab & JSXBase.HTMLAttributes<HTMLStencilaTabElement>;
             "stencila-tab-list": LocalJSX.StencilaTabList & JSXBase.HTMLAttributes<HTMLStencilaTabListElement>;
             "stencila-toast": LocalJSX.StencilaToast & JSXBase.HTMLAttributes<HTMLStencilaToastElement>;
+            "stencila-toast-container": LocalJSX.StencilaToastContainer & JSXBase.HTMLAttributes<HTMLStencilaToastContainerElement>;
             "stencila-toolbar": LocalJSX.StencilaToolbar & JSXBase.HTMLAttributes<HTMLStencilaToolbarElement>;
             "stencila-tooltip": LocalJSX.StencilaTooltip & JSXBase.HTMLAttributes<HTMLStencilaTooltipElement>;
             "stencila-tooltip-element": LocalJSX.StencilaTooltipElement & JSXBase.HTMLAttributes<HTMLStencilaTooltipElementElement>;

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -10,7 +10,6 @@ import { IconNames } from "./components/icon/iconNames";
 import { CodeChunk, CodeError, CodeExpression, Datatable, ImageObject, Node } from "@stencila/schema";
 import { Keymap } from "./components/editor/editor";
 import { EditorContents, Keymap as Keymap1 } from "./components/editor/editor";
-import { EditorSelection, Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { Config, Data, Layout } from "plotly.js";
 import { VisualizationSpec } from "vega-embed";
@@ -191,17 +190,17 @@ export namespace Components {
          */
         "foldGutter": boolean;
         /**
-          * Public method, returning the Editor contents and active language.
+          * Retrieve the Editor contents and active language.
          */
         "getContents": () => Promise<EditorContents>;
         /**
-          * Public method, returning a reference to the internal CodeMirror editor. Allows for maintaining state from applications making use of this component.
+          * Retrieve a reference to the internal CodeMirror editor. Allows for maintaining state from applications making use of this component.
          */
         "getRef": () => Promise<EditorView>;
         /**
-          * Disable language and other editor configuration management, deferring control to consuming applications
+          * Retrieve a JSON representation of the the internal editor state.
          */
-        "isControlled": boolean;
+        "getState": () => Promise<EditorStateJSON>;
         /**
           * Custom keyboard shortcuts to pass along to CodeMirror
           * @see https ://codemirror.net/6/docs/ref/#keymap
@@ -224,13 +223,17 @@ export namespace Components {
          */
         "readOnly": boolean;
         /**
-          * Public method, to replace the contents of the Editor with a supplied string.
+          * Replace the contents of the Editor with a supplied string.
          */
         "setContents": (contents: string) => Promise<string>;
         /**
-          * Public method, to completely replace the editor state with the given state. This replaces the editor configuration, edit history, language, etc.
+          * Update the internal editor state with the given JSON object.
          */
-        "setState": (contents: string, config?: EditorConfig | undefined, extensions?: Extension[] | undefined, selection?: EditorSelection | undefined) => Promise<string>;
+        "setState": (state: EditorStateJSON) => Promise<void>;
+        /**
+          * Create a new editor state from a given string. The string will be used as the initial contents of the editor.
+         */
+        "setStateFromString": (content: string) => Promise<void>;
     }
     interface StencilaExecutableDocumentToolbar {
         /**
@@ -742,10 +745,6 @@ declare namespace LocalJSX {
           * Enables ability to fold sections of code if the syntax package supports it
          */
         "foldGutter"?: boolean;
-        /**
-          * Disable language and other editor configuration management, deferring control to consuming applications
-         */
-        "isControlled"?: boolean;
         /**
           * Custom keyboard shortcuts to pass along to CodeMirror
           * @see https ://codemirror.net/6/docs/ref/#keymap

--- a/packages/components/src/components/editor/readme.md
+++ b/packages/components/src/components/editor/readme.md
@@ -13,7 +13,6 @@
 | `errors`               | --                | List of errors to display at the bottom of the code editor section. If the error is a `string`, then it will be rendered as a warning. | `CodeError[] \| string[] \| undefined`                          | `undefined`                                         |
 | `executeHandler`       | --                | Function to be evaluated over the contents of the editor.                                                                              | `((contents: EditorContents) => Promise<unknown>) \| undefined` | `undefined`                                         |
 | `foldGutter`           | `fold-gutter`     | Enables ability to fold sections of code if the syntax package supports it                                                             | `boolean`                                                       | `true`                                              |
-| `isControlled`         | `is-controlled`   | Disable language and other editor configuration management, deferring control to consuming applications                                | `boolean`                                                       | `false`                                             |
 | `keymap`               | --                | Custom keyboard shortcuts to pass along to CodeMirror                                                                                  | `KeyBinding[]`                                                  | `[]`                                                |
 | `languageCapabilities` | --                | List of all supported programming languages                                                                                            | `string[]`                                                      | `defaultLanguageCapabilities`                       |
 | `lineNumbers`          | `line-numbers`    | Determines the visibility of line numbers                                                                                              | `boolean`                                                       | `true`                                              |
@@ -32,7 +31,7 @@
 
 ### `getContents() => Promise<EditorContents>`
 
-Public method, returning the Editor contents and active language.
+Retrieve the Editor contents and active language.
 
 #### Returns
 
@@ -42,7 +41,7 @@ Type: `Promise<EditorContents>`
 
 ### `getRef() => Promise<EditorView>`
 
-Public method, returning a reference to the internal CodeMirror editor.
+Retrieve a reference to the internal CodeMirror editor.
 Allows for maintaining state from applications making use of this component.
 
 #### Returns
@@ -51,9 +50,19 @@ Type: `Promise<EditorView>`
 
 
 
+### `getState() => Promise<EditorStateJSON>`
+
+Retrieve a JSON representation of the the internal editor state.
+
+#### Returns
+
+Type: `Promise<EditorStateJSON>`
+
+
+
 ### `setContents(contents: string) => Promise<string>`
 
-Public method, to replace the contents of the Editor with a supplied string.
+Replace the contents of the Editor with a supplied string.
 
 #### Returns
 
@@ -61,14 +70,24 @@ Type: `Promise<string>`
 
 
 
-### `setState(contents: string, config?: EditorConfig | undefined, extensions?: Extension[] | undefined, selection?: EditorSelection | undefined) => Promise<string>`
+### `setState(state: EditorStateJSON) => Promise<void>`
 
-Public method, to completely replace the editor state with the given state.
-This replaces the editor configuration, edit history, language, etc.
+Update the internal editor state with the given JSON object.
 
 #### Returns
 
-Type: `Promise<string>`
+Type: `Promise<void>`
+
+
+
+### `setStateFromString(content: string) => Promise<void>`
+
+Create a new editor state from a given string.
+The string will be used as the initial contents of the editor.
+
+#### Returns
+
+Type: `Promise<void>`
 
 
 

--- a/packages/components/src/components/executableDocumentToolbar/readme.md
+++ b/packages/components/src/components/executableDocumentToolbar/readme.md
@@ -29,7 +29,7 @@
 - [stencila-icon](../icon)
 - [stencila-toolbar](../toolbar)
 - [stencila-button](../button)
-- animate-presence
+- [stencila-toast-container](../toastContainer)
 - [stencila-toast](../toast)
 
 ### Graph
@@ -39,14 +39,17 @@ graph TD;
   stencila-executable-document-toolbar --> stencila-icon
   stencila-executable-document-toolbar --> stencila-toolbar
   stencila-executable-document-toolbar --> stencila-button
-  stencila-executable-document-toolbar --> animate-presence
+  stencila-executable-document-toolbar --> stencila-toast-container
   stencila-executable-document-toolbar --> stencila-toast
   stencila-tooltip --> stencila-tooltip-element
   stencila-button --> stencila-icon
   stencila-button --> stencila-tooltip
+  stencila-toast-container --> animate-presence
+  stencila-toast-container --> stencila-toast-container
+  stencila-toast-container --> stencila-toast
   stencila-toast --> stencila-icon
   stencila-toast --> stencila-button
-  stencila-toast --> animate-presence
+  stencila-toast --> stencila-toast-container
   stencila-toast --> stencila-toast
   style stencila-executable-document-toolbar fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/components/src/components/toast/readme.md
+++ b/packages/components/src/components/toast/readme.md
@@ -29,12 +29,13 @@
 
  - [stencila-executable-document-toolbar](../executableDocumentToolbar)
  - [stencila-toast](.)
+ - [stencila-toast-container](../toastContainer)
 
 ### Depends on
 
 - [stencila-icon](../icon)
 - [stencila-button](../button)
-- animate-presence
+- [stencila-toast-container](../toastContainer)
 - [stencila-toast](.)
 
 ### Graph
@@ -44,6 +45,7 @@ graph TD;
   stencila-button --> stencila-icon
   stencila-button --> stencila-tooltip
   stencila-tooltip --> stencila-tooltip-element
+  stencila-toast-container --> stencila-toast
   stencila-executable-document-toolbar --> stencila-toast
   style stencila-toast fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/components/src/components/toast/toast.tsx
+++ b/packages/components/src/components/toast/toast.tsx
@@ -116,7 +116,7 @@ export class StencilaToast {
       <Host
         type={this.type}
         position={this.position}
-        dismissable={this.dismissable}
+        dismissable={this.dismissable || this.duration === 0}
         onMouseEnter={this.pauseAutoDismiss}
         onMouseLeave={this.autoDismiss}
       >

--- a/packages/components/src/components/toast/toastController.ts
+++ b/packages/components/src/components/toast/toastController.ts
@@ -24,21 +24,16 @@ export type ToastPosition = keyof typeof ToastPositions
 type ToastOptions = Partial<Components.StencilaToast>
 
 const init = (options: ToastOptions): Element | HTMLElement => {
-  const toastContainer = document.querySelector('.stencila-toast-container')
+  const toastContainer = document.querySelector('stencila-toast-container')
 
   if (toastContainer) {
     return toastContainer
   }
 
-  const container = document.createElement('animate-presence')
-  container.classList.add('stencila-toast-container')
-  container.setAttribute('aria-live', 'polite')
-  container.setAttribute('role', 'status')
-  // TODO: Look into `aria-relevant="additions"` not silencing node removals in VoiceOver
-  container.setAttribute('aria-relevant', 'additions')
+  const container = document.createElement('stencila-toast-container')
 
   if (options.position !== undefined) {
-    container.setAttribute('position', options.position)
+    container.position = options.position
   }
 
   document.body.append(container)

--- a/packages/components/src/components/toastContainer/readme.md
+++ b/packages/components/src/components/toastContainer/readme.md
@@ -1,0 +1,43 @@
+# stencila-toast-container
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property   | Attribute  | Description                                                                                | Type                                                                                      | Default                    |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------- |
+| `position` | `position` | Default position of Toasts on the screen. Can be overridden by individual Toast instances. | `"bottomCenter" \| "bottomEnd" \| "bottomStart" \| "topCenter" \| "topEnd" \| "topStart"` | `ToastPositions.topCenter` |
+
+
+## Dependencies
+
+### Used by
+
+ - [stencila-executable-document-toolbar](../executableDocumentToolbar)
+ - [stencila-toast](../toast)
+ - [stencila-toast-container](.)
+
+### Depends on
+
+- animate-presence
+- [stencila-toast-container](.)
+- [stencila-toast](../toast)
+
+### Graph
+```mermaid
+graph TD;
+  stencila-toast-container --> stencila-toast-container
+  stencila-toast --> stencila-toast-container
+  stencila-button --> stencila-icon
+  stencila-button --> stencila-tooltip
+  stencila-tooltip --> stencila-tooltip-element
+  stencila-executable-document-toolbar --> stencila-toast-container
+  style stencila-toast-container fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/components/src/components/toastContainer/toastContainer.tsx
+++ b/packages/components/src/components/toastContainer/toastContainer.tsx
@@ -1,0 +1,32 @@
+import { Component, h, Host, Prop } from '@stencil/core'
+import { ToastPosition, ToastPositions } from '../toast/toastController'
+
+/*
+ * Target container for `stencila-toast` elements.
+ * Only one `stencila-toast-container` element should be present on the page.
+ */
+@Component({
+  tag: 'stencila-toast-container',
+})
+export class StencilaToastContainer {
+  /**
+   * Default position of Toasts on the screen.
+   * Can be overridden by individual Toast instances.
+   */
+  @Prop() position: ToastPosition = ToastPositions.topCenter
+
+  render() {
+    return (
+      <Host class="stencila-toast-container" position={this.position}>
+        <animate-presence
+          aria-live="polite"
+          role="status"
+          // TODO: Look into `aria-relevant="additions"` not silencing node removals in VoiceOver
+          aria-relevant="additions"
+        >
+          <slot />
+        </animate-presence>
+      </Host>
+    )
+  }
+}

--- a/stories/atoms/toast/toast.stories.js
+++ b/stories/atoms/toast/toast.stories.js
@@ -26,6 +26,11 @@ export default {
         'bottomEnd',
       ],
     },
+    dismissable: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 }
 
@@ -43,7 +48,7 @@ export const toast = ({ type, duration, position, dismissable }) =>
 
 export const dismissable = ({ type, duration, position, dismissable }) =>
   html`
-    <animate-presence class="stencila-toast-container" .position=${position}>
+    <stencila-toast-container .position=${position}>
       <stencila-toast
         .type=${type}
         .duration=${duration}
@@ -84,7 +89,7 @@ export const dismissable = ({ type, duration, position, dismissable }) =>
       >
         This is a simple toast
       </stencila-toast>
-    </animate-presence>
+    </stencila-toast-container>
   `
 dismissable.args = {
   dismissable: true,
@@ -92,7 +97,7 @@ dismissable.args = {
 
 export const withAction = ({ type, duration, position, dismissable }) =>
   html`
-    <animate-presence class="stencila-toast-container" .position=${position}>
+    <stencila-toast-container .position=${position}>
       <stencila-toast
         .type=${type}
         .duration=${duration}
@@ -157,7 +162,7 @@ export const withAction = ({ type, duration, position, dismissable }) =>
           <stencila-button>Action</stencila-button>
         </div>
       </stencila-toast>
-    </animate-presence>
+    </stencila-toast-container>
   `
 withAction.args = {
   dismissable: true,


### PR DESCRIPTION
This PR:
- refactors the editor `get/setState` methods to include the edit history as part of the JSON serialization/deserialization process. This greatly simplifies the storage and rehydration of the editor state in the Desktop client.
- Bumps the minimum version requirement for `@stencila/schema` to ensure that the correct node type guards are available
- adds a new `stencila-toast-container` component. This allows for finer-grained usage of the toast notifications in other applications, such as showing actionable toast messages in the Desktop.
- updates the BrowserList database
