### PR TITLE
Fix fetching of icons across origins

### DIFF
--- a/packages/components/src/components/icon/icon.tsx
+++ b/packages/components/src/components/icon/icon.tsx
@@ -58,7 +58,11 @@ export class Icon {
     return (
       <Host icon={this.icon} aria-hidden="true">
         <svg>
-          <use href={`#ri-${this.icon}-${this.iconStyle}`}></use>
+          <use
+            href={`#ri-${this.icon}${
+              this.iconStyle !== undefined ? '-' + this.iconStyle : ''
+            }`}
+          ></use>
         </svg>
       </Host>
     )

--- a/packages/components/src/components/icon/icon.tsx
+++ b/packages/components/src/components/icon/icon.tsx
@@ -1,5 +1,8 @@
-import { Component, h, Host, Prop, getAssetPath } from '@stencil/core'
+import { Component, getAssetPath, h, Host, Prop } from '@stencil/core'
+import wretch from 'wretch'
 import { IconNames } from './iconNames'
+
+let isFetchingIcons = false
 
 const getGlobalIconStyle = () =>
   document.getElementsByTagName('html')[0].getAttribute('data-icon-style') ===
@@ -30,15 +33,32 @@ export class Icon {
   @Prop()
   public readonly iconStyle: 'fill' | 'line' = getGlobalIconStyle()
 
+  private fetchIcons = async () => {
+    const response = await wretch()
+      .url(getAssetPath(`./assets/remixicon.symbol.svg`))
+      .options({ credentials: 'omit', mode: 'cors' })
+      .get()
+      .text()
+
+    const div = document.createElement('div')
+    div.innerHTML = response
+    document.body.append(div)
+  }
+
+  componentWillLoad() {
+    if (!isFetchingIcons) {
+      isFetchingIcons = true
+      this.fetchIcons().catch((err) => {
+        console.log('Failed to load icons', err)
+      })
+    }
+  }
+
   public render() {
     return (
       <Host icon={this.icon} aria-hidden="true">
         <svg>
-          <use
-            href={`${getAssetPath(`./assets/remixicon.symbol.svg`)}#ri-${
-              this.icon
-            }-${this.iconStyle}`}
-          ></use>
+          <use href={`#ri-${this.icon}-${this.iconStyle}`}></use>
         </svg>
       </Host>
     )


### PR DESCRIPTION
- Fix fetching of icon sprites across origins to avoid CORS issues
- Allow using RemixIcons which don't have a style suffix. To do so, set the `iconStyle` prop to an empty string