### PR TITLE
Fix CodeChunk programming language mapping, and misc. button style fixes

### DIFF
--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -154,7 +154,7 @@ export class Button {
 
   public render() {
     return (
-      <Host size={this.size} tabindex="-1" icon={this.icon}>
+      <Host size={this.size} icon={this.icon}>
         {this.tooltip === undefined ? (
           this.generateButton()
         ) : (

--- a/packages/components/src/components/button/test/button.spec.tsx
+++ b/packages/components/src/components/button/test/button.spec.tsx
@@ -1,17 +1,18 @@
 import { newSpecPage } from '@stencil/core/testing'
 import { Button } from '../button'
 
-const getEl = (html?: string) => newSpecPage({
-  components: [Button],
-  html: html ?? `<stencila-button>Hello there</stencila-button>`,
-})
+const getEl = (html?: string) =>
+  newSpecPage({
+    components: [Button],
+    html: html ?? `<stencila-button>Hello there</stencila-button>`,
+  })
 
 describe('button', () => {
   it('renders', async () => {
     const page = await getEl()
 
     expect(page.root).toEqualHtml(`
-      <stencila-button size="default" tabindex="-1">
+      <stencila-button size="default">
         <button class="color-primary default">
           <span class="label">Hello there</span>
         </button>
@@ -20,10 +21,12 @@ describe('button', () => {
   })
 
   it('renders an anchor link', async () => {
-    const page = await getEl(`<stencila-button href="#">Hello there</stencila-button>`)
+    const page = await getEl(
+      `<stencila-button href="#">Hello there</stencila-button>`
+    )
 
     expect(page.root).toEqualHtml(`
-      <stencila-button href="#" size="default" tabindex="-1">
+      <stencila-button href="#" size="default">
         <a class="button color-primary default" href="#">
           <span class="label">Hello there</span>
         </a>

--- a/packages/components/src/components/editor/editor.tsx
+++ b/packages/components/src/components/editor/editor.tsx
@@ -474,7 +474,7 @@ export class Editor {
       text: this.editorRef?.state.doc.toString() ?? '',
       language: lookupFormat(
         this.languagePickerRef?.value ?? this.activeLanguage
-      ).name,
+      ).name.toLowerCase(),
     })
   }
 

--- a/packages/style-material/cssnano.config.js
+++ b/packages/style-material/cssnano.config.js
@@ -8,6 +8,7 @@ module.exports = {
           return !(comment.startsWith('!') || comment.includes('@prop'))
         },
       },
+      reduceIdents: false,
     },
   ],
 }

--- a/packages/style-material/src/atoms/button/index.css
+++ b/packages/style-material/src/atoms/button/index.css
@@ -59,7 +59,7 @@ a.button {
     &[disabled]:focus,
     &[disabled]:active,
     &[disabled]:hover {
-      @apply text-key;
+      color: var(--color-key, #000) !important;
       mix-blend-mode: soft-light;
       opacity: 0.65;
 

--- a/packages/style-stencila/cssnano.config.js
+++ b/packages/style-stencila/cssnano.config.js
@@ -8,6 +8,7 @@ module.exports = {
           return !(comment.startsWith('!') || comment.includes('@prop'))
         },
       },
+      reduceIdents: false,
     },
   ],
 }

--- a/packages/style-stencila/src/atoms/button/index.css
+++ b/packages/style-stencila/src/atoms/button/index.css
@@ -59,7 +59,7 @@ a.button {
     &[disabled]:focus,
     &[disabled]:active,
     &[disabled]:hover {
-      @apply text-key;
+      color: var(--color-key, #000) !important;
       mix-blend-mode: soft-light;
       opacity: 0.65;
 


### PR DESCRIPTION
Resolves issues with code execution when interfacing with Executa.
Executa expects the code node programming language to be lowercase (e.g. `python', instead of `Python`).
This is done by lowercasing the programming language.

Additionally this PR makes some minor refinements:
- Doesn't [optimize/rename CSS animation keyframes](https://github.com/cssnano/cssnano/tree/master/packages/postcss-reduce-idents#postcss-reduce-idents), this reduces clashes when the components are used in conjunction with other CSS stylesheets, such as from Thema.
- Fixes issue with buttons trapping/persisting the focus ring after being clicked
- Attempts to fix issue with minimal loading button icons not being legible when color was overridden by Thema stylesheets