### PR TITLE
docs(Storybook): Remove HTML Microdata for code chunk and code expression stories

### DIFF
--- a/stories/molecules/codeChunk/codeChunk.stories.js
+++ b/stories/molecules/codeChunk/codeChunk.stories.js
@@ -57,7 +57,6 @@ export const singleCodeChunk = ({ programmingLanguage }) => html`
   <div>
     <stencila-code-chunk
       data-collapsed="false"
-      itemtype="stencila:CodeChunk"
       .programmingLanguage=${programmingLanguage}
     >
       <pre slot="text"><code>print(a)</code></pre>
@@ -70,7 +69,7 @@ export const singleCodeChunk = ({ programmingLanguage }) => html`
 
 export const multipleCodeChunks = () => html`
   <div>
-    <stencila-code-chunk data-collapsed="false" itemtype="stencila:CodeChunk">
+    <stencila-code-chunk data-collapsed="false">
       <pre slot="text"><code>print(a)</code></pre>
       <figure slot="outputs">
         <pre><output>10</output></pre>
@@ -85,8 +84,8 @@ export const multipleCodeChunks = () => html`
       therefore runs Python code.
     </p>
 
-    <stencila-code-chunk data-collapsed="false" itemtype="stencila:CodeChunk">
-      <pre slot="text" itemprop="code"><code>print(second)</code></pre>
+    <stencila-code-chunk data-collapsed="false">
+      <pre slot="text"><code>print(second)</code></pre>
 
       <figure slot="outputs">
         <img
@@ -100,8 +99,8 @@ export const multipleCodeChunks = () => html`
 
 export const withMultipleOutputs = () => html`
   <div>
-    <stencila-code-chunk data-collapsed="false" itemtype="stencila:CodeChunk">
-      <pre slot="text" itemprop="code"><code>print(second)</code></pre>
+    <stencila-code-chunk data-collapsed="false">
+      <pre slot="text"><code>print(second)</code></pre>
 
       <figure slot="outputs">
         <pre><output>10</output></pre>
@@ -122,8 +121,8 @@ export const withMultipleOutputs = () => html`
 `
 export const withNoOutputContent = () => html`
   <div>
-    <stencila-code-chunk itemtype="stencila:CodeChunk">
-      <pre slot="text" itemprop="code"><code>print(second)</code></pre>
+    <stencila-code-chunk>
+      <pre slot="text"><code>print(second)</code></pre>
 
       <figure slot="outputs"></figure>
     </stencila-code-chunk>
@@ -132,8 +131,8 @@ export const withNoOutputContent = () => html`
 
 export const withNoOutputSlot = () => html`
   <div>
-    <stencila-code-chunk itemtype="stencila:CodeChunk">
-      <pre slot="text" itemprop="code"><code>print(second)</code></pre>
+    <stencila-code-chunk>
+      <pre slot="text"><code>print(second)</code></pre>
     </stencila-code-chunk>
   </div>
 `
@@ -141,13 +140,13 @@ export const withNoOutputSlot = () => html`
 export const alongsideACodeExpression = () => html`
   <div>
     <p>
-      This is a paragraph with a code expresssion inside it
-      <stencila-code-expression itemtype="stencila:CodeExpression"
+      This is a paragraph with a code expression inside it
+      <stencila-code-expression
         ><code slot="text">x * y</code
         ><output slot="output">42</output></stencila-code-expression
       >
       followed by some more text and another
-      <stencila-code-expression itemtype="stencila:CodeExpression">
+      <stencila-code-expression>
         <code slot="text"
           >x * y - 128 * (212 - 2) x * y - 128 * (212 - 2)
           round(length(which((silent_1hr_l1-silent_0hr_l1)>0))/length(silent_0hr_l1)*100)</code
@@ -157,8 +156,8 @@ export const alongsideACodeExpression = () => html`
         > </stencila-code-expression
       >.
     </p>
-    <stencila-code-chunk itemtype="stencila:CodeChunk">
-      <pre slot="text" itemprop="code"><code>print(second)</code></pre>
+    <stencila-code-chunk>
+      <pre slot="text"><code>print(second)</code></pre>
 
       <figure slot="outputs">
         <pre><output>10</output></pre>

--- a/stories/molecules/codeExpression/codeExpression.stories.js
+++ b/stories/molecules/codeExpression/codeExpression.stories.js
@@ -17,27 +17,20 @@ export const codeExpression = () => html`
   <div>
     <stencila-code-expression
       programming-language="r"
-      itemscope=""
-      itemtype="http://schema.stenci.la/CodeExpression"
       .executeHandler=${handler}
     >
       <code class="r" slot="text"
         >length(subset(data2, Lot==1 &amp; Time==0)$value)</code
       >
-      <output slot="output"
-        ><span data-itemtype="http://schema.org/Number">3</span></output
-      >
+      <output slot="output">3</output>
     </stencila-code-expression>
   </div>
 `
 
 export const codeExpressionInAParagraph = () => html`
   <p>
-    This is a paragraph with a code expresssion inside it
-    <stencila-code-expression
-      data-collapsed="false"
-      itemtype="stencila:CodeChunk"
-    >
+    This is a paragraph with a code expression inside it
+    <stencila-code-expression data-collapsed="false">
       <code slot="text">x * y </code>
       <output slot="output">42</output></stencila-code-expression
     >
@@ -47,11 +40,8 @@ export const codeExpressionInAParagraph = () => html`
 
 export const multipleCodeExpressionsInAParagraph = () => html`
   <p>
-    This is a paragraph with a code expresssion inside it
-    <stencila-code-expression
-      data-collapsed="false"
-      itemtype="stencila:CodeChunk"
-    >
+    This is a paragraph with a code expression inside it
+    <stencila-code-expression data-collapsed="false">
       <code slot="text">x * y</code>
       <output slot="output">42</output></stencila-code-expression
     >
@@ -70,10 +60,8 @@ export const multipleCodeExpressionsInAParagraph = () => html`
 
 export const codeExpressionWithAnImageOutput = () => html`
   <p>
-    This is a paragraph with a code expresssion inside it
-    <stencila-code-expression
-      data-collapsed="false"
-      itemtype="stencila:CodeChunk"
+    This is a paragraph with a code expression inside it
+    <stencila-code-expression data-collapsed="false"
       ><code slot="text">x * y</code
       ><output slot="output">42</output></stencila-code-expression
     >
@@ -92,10 +80,8 @@ export const codeExpressionWithAnImageOutput = () => html`
 
 export const codeExpressionWithNoOutput = () => html`
   <p>
-    This is a paragraph with a code expresssion inside it
-    <stencila-code-expression
-      data-collapsed="false"
-      itemtype="stencila:CodeChunk"
+    This is a paragraph with a code expression inside it
+    <stencila-code-expression data-collapsed="false"
       ><code slot="text">x * y</code><output slot="output"></output
     ></stencila-code-expression>
     followed by some more text.
@@ -104,10 +90,8 @@ export const codeExpressionWithNoOutput = () => html`
 
 export const codeExpressionWithSymbolsInOutput = () => html`
   <p>
-    This is a paragraph with a code expresssion inside it
-    <stencila-code-expression
-      data-collapsed="false"
-      itemtype="stencila:CodeChunk"
+    This is a paragraph with a code expression inside it
+    <stencila-code-expression data-collapsed="false"
       ><code slot="text">x * y</code
       ><output slot="output">&lt;0.001</output></stencila-code-expression
     >


### PR DESCRIPTION
While checking the Storybook, I noticed that some of the HTML Microdata (specifically some `itemtype` attributes) were wrong. Since rendering / functioning of component does not depend upon these attributes (other than customisation in themes (?)), it seems better to remove them to avoid confusion.
