### PR TITLE
Centre project graphs

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -8,6 +8,14 @@
 <script nomodule src="./stencila-components/stencila-components.js"></script>
 
 <style>
+    html,
+    body,
+    .sb-main-fullscreen #root,
+    .sb-main-fullscreen #root-inner {
+        height: 100%;
+        width: 100%;
+    }
+
     /*
    * These styles rest styles for the Storybook UI elements broken
    * by the Style Stencila CSS

--- a/packages/components/src/components/projectGraph/projectGraph.tsx
+++ b/packages/components/src/components/projectGraph/projectGraph.tsx
@@ -59,7 +59,7 @@ export class ProjectGraph {
     | undefined
 
   private drawGraph = (graph: Graph) => {
-    const { svg, width, height } = this.graphRef
+    const { svg } = this.graphRef
 
     const groupedGraph = graphToGroupedGraph(graph)
 
@@ -106,7 +106,7 @@ export class ProjectGraph {
       .force('collision', forceCollide(64).strength(1).iterations(4))
       .force('x', forceX().strength(0.02))
       .force('y', forceY().strength(0.02))
-      .force('center', forceCenter(width / 2, height / 2))
+      .force('center', forceCenter())
       .velocityDecay(0.4)
       .alphaDecay(0.05)
 


### PR DESCRIPTION
- Add styles to Storybook container to make fullscreen stories actually fullscreen
- Use canvas centre point for centring the graph.