### PR TITLE
Editor: Remove optgroups from list of languages

### DIFF
--- a/packages/components/src/components/editor/components/languageSelect.tsx
+++ b/packages/components/src/components/editor/components/languageSelect.tsx
@@ -29,22 +29,8 @@ export const LanguagePicker = (props: Props): FunctionalComponent => {
     <label aria-label="Programming Language">
       <stencila-icon icon="terminal"></stencila-icon>
       <select onChange={props.onSetLanguage} ref={props.setRef}>
-        <optgroup label="Executable">
-          {hasExecutableLanguages ? (
-            Object.values(props.executableLanguages).map((language) => (
-              <option
-                value={language.name}
-                selected={language.name === activeLanguageByAlias.name}
-              >
-                {language.name}
-              </option>
-            ))
-          ) : (
-            <option disabled>None available</option>
-          )}
-        </optgroup>
-        <optgroup label="All languages">
-          {Object.values(filteredLanguages).map((language) => (
+        {hasExecutableLanguages &&
+          Object.values(props.executableLanguages).map((language) => (
             <option
               value={language.name}
               selected={language.name === activeLanguageByAlias.name}
@@ -52,7 +38,17 @@ export const LanguagePicker = (props: Props): FunctionalComponent => {
               {language.name}
             </option>
           ))}
-        </optgroup>
+
+        <option disabled>Non-executable</option>
+
+        {Object.values(filteredLanguages).map((language) => (
+          <option
+            value={language.name}
+            selected={language.name === activeLanguageByAlias.name}
+          >
+            {language.name}
+          </option>
+        ))}
       </select>
     </label>
   )

--- a/stories/atoms/editor/editor.stories.js
+++ b/stories/atoms/editor/editor.stories.js
@@ -5,6 +5,9 @@ export default {
   title: 'Atoms/Editor',
   component: 'stencila-editor',
   argTypes: {
+    activeLanguage: {
+      defaultValue: 'Python',
+    },
     executableLanguages: {
       control: { type: 'object' },
       defaultValue: {
@@ -52,6 +55,7 @@ const appendError = () => {
 }
 
 export const editor = ({
+  activeLanguage,
   lineNumbers,
   text,
   lineWrapping,
@@ -63,6 +67,7 @@ export const editor = ({
     <button @click=${appendError}>Add errors</button>
 
     <stencila-editor
+      .activeLanguage=${activeLanguage}
       .lineNumbers=${lineNumbers}
       .lineWrapping=${lineWrapping}
       .foldGutter=${foldGutter}


### PR DESCRIPTION
This change is due to an issue with Firefox with dynamic optgroup lists.
When re-rendering, Firefox would incorrectly always set the first item
from the first optgroup as selected.

@nokome, this was the only solution I was able to come up with unfortunately.
Down the road we can possibly look into using a third-party component instead of the browser native select elements, which could provide a workaround for this.
Meanwhile, I've added a disabled `option` element as a makeshift divider within the list.

![Screenshot 2021-12-02 at 16 56 43](https://user-images.githubusercontent.com/1646307/144510056-18d7e765-ba2c-4e4f-973d-da1021bf710f.png)

