### PR TITLE
Add Code Fragment and Code Block components

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@stencila/components",
-      "version": "0.44.1",
+      "version": "0.44.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^0.19.3",

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -7,9 +7,9 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Colors } from "./types";
 import { IconNames } from "./components/icon/iconNames";
-import { CodeChunk, CodeError, CodeExpression, ImageObject } from "@stencila/schema";
 import { FileFormat, FileFormatMap } from "./components/editor/languageUtils";
 import { Keymap } from "./components/editor/editor";
+import { CodeBlock, CodeChunk, CodeError, CodeExpression, ImageObject } from "@stencila/schema";
 import { EditorContents, EditorStateJSON, Keymap as Keymap1 } from "./components/editor/editor";
 import { EditorUpdateHandlerCb } from "./components/editor/customizations/onUpdateHandlerExtension";
 import { EditorView, ViewUpdate } from "@codemirror/view";
@@ -93,6 +93,45 @@ export namespace Components {
           * An optional help text to display for button focus and hover states.
          */
         "tooltip"?: string;
+    }
+    interface StencilaCodeBlock {
+        /**
+          * Autofocus the editor on page load
+         */
+        "autofocus": boolean;
+        /**
+          * List of programming languages that can be executed in the current context
+         */
+        "executableLanguages": FileFormatMap;
+        /**
+          * Enables ability to fold sections of code if the syntax package supports it
+         */
+        "foldGutter": boolean;
+        /**
+          * Returns the `CodeChunk` node with the updated `text` content from the editor.
+         */
+        "getContents": () => Promise<CodeBlock>;
+        /**
+          * Custom keyboard shortcuts to pass along to CodeMirror
+          * @see https://codemirror.net/6/docs/ref/#keymap
+         */
+        "keymap": Keymap[];
+        /**
+          * Determines the visibility of line numbers
+         */
+        "lineNumbers": boolean;
+        /**
+          * Control line wrapping of text inside the editor
+         */
+        "lineWrapping": boolean;
+        /**
+          * Programming language of the CodeChunk
+         */
+        "programmingLanguage": string | undefined;
+        /**
+          * Disallow editing of the editor contents when set to `true`
+         */
+        "readOnly": boolean;
     }
     interface StencilaCodeChunk {
         /**
@@ -477,6 +516,12 @@ declare global {
         prototype: HTMLStencilaButtonElement;
         new (): HTMLStencilaButtonElement;
     };
+    interface HTMLStencilaCodeBlockElement extends Components.StencilaCodeBlock, HTMLStencilElement {
+    }
+    var HTMLStencilaCodeBlockElement: {
+        prototype: HTMLStencilaCodeBlockElement;
+        new (): HTMLStencilaCodeBlockElement;
+    };
     interface HTMLStencilaCodeChunkElement extends Components.StencilaCodeChunk, HTMLStencilElement {
     }
     var HTMLStencilaCodeChunkElement: {
@@ -624,6 +669,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "stencila-action-menu": HTMLStencilaActionMenuElement;
         "stencila-button": HTMLStencilaButtonElement;
+        "stencila-code-block": HTMLStencilaCodeBlockElement;
         "stencila-code-chunk": HTMLStencilaCodeChunkElement;
         "stencila-code-error": HTMLStencilaCodeErrorElement;
         "stencila-code-expression": HTMLStencilaCodeExpressionElement;
@@ -724,6 +770,41 @@ declare namespace LocalJSX {
           * An optional help text to display for button focus and hover states.
          */
         "tooltip"?: string;
+    }
+    interface StencilaCodeBlock {
+        /**
+          * Autofocus the editor on page load
+         */
+        "autofocus"?: boolean;
+        /**
+          * List of programming languages that can be executed in the current context
+         */
+        "executableLanguages"?: FileFormatMap;
+        /**
+          * Enables ability to fold sections of code if the syntax package supports it
+         */
+        "foldGutter"?: boolean;
+        /**
+          * Custom keyboard shortcuts to pass along to CodeMirror
+          * @see https://codemirror.net/6/docs/ref/#keymap
+         */
+        "keymap"?: Keymap[];
+        /**
+          * Determines the visibility of line numbers
+         */
+        "lineNumbers"?: boolean;
+        /**
+          * Control line wrapping of text inside the editor
+         */
+        "lineWrapping"?: boolean;
+        /**
+          * Programming language of the CodeChunk
+         */
+        "programmingLanguage"?: string | undefined;
+        /**
+          * Disallow editing of the editor contents when set to `true`
+         */
+        "readOnly"?: boolean;
     }
     interface StencilaCodeChunk {
         /**
@@ -1089,6 +1170,7 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "stencila-action-menu": StencilaActionMenu;
         "stencila-button": StencilaButton;
+        "stencila-code-block": StencilaCodeBlock;
         "stencila-code-chunk": StencilaCodeChunk;
         "stencila-code-error": StencilaCodeError;
         "stencila-code-expression": StencilaCodeExpression;
@@ -1121,6 +1203,7 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "stencila-action-menu": LocalJSX.StencilaActionMenu & JSXBase.HTMLAttributes<HTMLStencilaActionMenuElement>;
             "stencila-button": LocalJSX.StencilaButton & JSXBase.HTMLAttributes<HTMLStencilaButtonElement>;
+            "stencila-code-block": LocalJSX.StencilaCodeBlock & JSXBase.HTMLAttributes<HTMLStencilaCodeBlockElement>;
             "stencila-code-chunk": LocalJSX.StencilaCodeChunk & JSXBase.HTMLAttributes<HTMLStencilaCodeChunkElement>;
             "stencila-code-error": LocalJSX.StencilaCodeError & JSXBase.HTMLAttributes<HTMLStencilaCodeErrorElement>;
             "stencila-code-expression": LocalJSX.StencilaCodeExpression & JSXBase.HTMLAttributes<HTMLStencilaCodeExpressionElement>;

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -166,12 +166,20 @@ export namespace Components {
           * Programming language of the CodeExpression
          */
         "programmingLanguage": string;
+        /**
+          * Disallow editing of the editor contents when set to `true`
+         */
+        "readOnly": boolean;
     }
     interface StencilaCodeFragment {
         /**
           * Programming language of the CodeFragment
          */
         "programmingLanguage": string | undefined;
+        /**
+          * Disallow editing of the editor contents when set to `true`
+         */
+        "readOnly": boolean;
     }
     interface StencilaDataTable {
     }
@@ -785,6 +793,10 @@ declare namespace LocalJSX {
           * Programming language of the CodeExpression
          */
         "programmingLanguage"?: string;
+        /**
+          * Disallow editing of the editor contents when set to `true`
+         */
+        "readOnly"?: boolean;
     }
     interface StencilaCodeFragment {
         /**
@@ -795,6 +807,10 @@ declare namespace LocalJSX {
           * Programming language of the CodeFragment
          */
         "programmingLanguage"?: string | undefined;
+        /**
+          * Disallow editing of the editor contents when set to `true`
+         */
+        "readOnly"?: boolean;
     }
     interface StencilaDataTable {
     }

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -167,6 +167,12 @@ export namespace Components {
          */
         "programmingLanguage": string;
     }
+    interface StencilaCodeFragment {
+        /**
+          * Programming language of the CodeFragment
+         */
+        "programmingLanguage": string | undefined;
+    }
     interface StencilaDataTable {
     }
     interface StencilaDetails {
@@ -360,6 +366,10 @@ export namespace Components {
     }
     interface StencilaMenu {
         /**
+          * Close the menu when losing focus
+         */
+        "autoClose": boolean;
+        /**
           * Determines whether the Menu is shown or not
          */
         "isOpen": boolean;
@@ -370,6 +380,10 @@ export namespace Components {
           * @see Icon component for possible values
          */
         "icon": IconNames | undefined;
+        /**
+          * The overall size of the component.
+         */
+        "size": 'xsmall' | 'small' | 'default' | 'large';
     }
     interface StencilaNodeList {
     }
@@ -472,6 +486,12 @@ declare global {
     var HTMLStencilaCodeExpressionElement: {
         prototype: HTMLStencilaCodeExpressionElement;
         new (): HTMLStencilaCodeExpressionElement;
+    };
+    interface HTMLStencilaCodeFragmentElement extends Components.StencilaCodeFragment, HTMLStencilElement {
+    }
+    var HTMLStencilaCodeFragmentElement: {
+        prototype: HTMLStencilaCodeFragmentElement;
+        new (): HTMLStencilaCodeFragmentElement;
     };
     interface HTMLStencilaDataTableElement extends Components.StencilaDataTable, HTMLStencilElement {
     }
@@ -599,6 +619,7 @@ declare global {
         "stencila-code-chunk": HTMLStencilaCodeChunkElement;
         "stencila-code-error": HTMLStencilaCodeErrorElement;
         "stencila-code-expression": HTMLStencilaCodeExpressionElement;
+        "stencila-code-fragment": HTMLStencilaCodeFragmentElement;
         "stencila-data-table": HTMLStencilaDataTableElement;
         "stencila-details": HTMLStencilaDetailsElement;
         "stencila-editor": HTMLStencilaEditorElement;
@@ -757,9 +778,23 @@ declare namespace LocalJSX {
     codeExpression: CodeExpression
   ) => Promise<CodeExpression>;
         /**
+          * Event emitted when the language of the editor is changed.
+         */
+        "onStencila-language-change"?: (event: CustomEvent<FileFormat>) => void;
+        /**
           * Programming language of the CodeExpression
          */
         "programmingLanguage"?: string;
+    }
+    interface StencilaCodeFragment {
+        /**
+          * Event emitted when the language of the editor is changed.
+         */
+        "onStencila-language-change"?: (event: CustomEvent<FileFormat>) => void;
+        /**
+          * Programming language of the CodeFragment
+         */
+        "programmingLanguage"?: string | undefined;
     }
     interface StencilaDataTable {
     }
@@ -946,6 +981,10 @@ declare namespace LocalJSX {
     }
     interface StencilaMenu {
         /**
+          * Close the menu when losing focus
+         */
+        "autoClose"?: boolean;
+        /**
           * Determines whether the Menu is shown or not
          */
         "isOpen"?: boolean;
@@ -956,6 +995,10 @@ declare namespace LocalJSX {
           * @see Icon component for possible values
          */
         "icon"?: IconNames | undefined;
+        /**
+          * The overall size of the component.
+         */
+        "size"?: 'xsmall' | 'small' | 'default' | 'large';
     }
     interface StencilaNodeList {
     }
@@ -1033,6 +1076,7 @@ declare namespace LocalJSX {
         "stencila-code-chunk": StencilaCodeChunk;
         "stencila-code-error": StencilaCodeError;
         "stencila-code-expression": StencilaCodeExpression;
+        "stencila-code-fragment": StencilaCodeFragment;
         "stencila-data-table": StencilaDataTable;
         "stencila-details": StencilaDetails;
         "stencila-editor": StencilaEditor;
@@ -1064,6 +1108,7 @@ declare module "@stencil/core" {
             "stencila-code-chunk": LocalJSX.StencilaCodeChunk & JSXBase.HTMLAttributes<HTMLStencilaCodeChunkElement>;
             "stencila-code-error": LocalJSX.StencilaCodeError & JSXBase.HTMLAttributes<HTMLStencilaCodeErrorElement>;
             "stencila-code-expression": LocalJSX.StencilaCodeExpression & JSXBase.HTMLAttributes<HTMLStencilaCodeExpressionElement>;
+            "stencila-code-fragment": LocalJSX.StencilaCodeFragment & JSXBase.HTMLAttributes<HTMLStencilaCodeFragmentElement>;
             "stencila-data-table": LocalJSX.StencilaDataTable & JSXBase.HTMLAttributes<HTMLStencilaDataTableElement>;
             "stencila-details": LocalJSX.StencilaDetails & JSXBase.HTMLAttributes<HTMLStencilaDetailsElement>;
             "stencila-editor": LocalJSX.StencilaEditor & JSXBase.HTMLAttributes<HTMLStencilaEditorElement>;

--- a/packages/components/src/components/button/readme.md
+++ b/packages/components/src/components/button/readme.md
@@ -32,6 +32,7 @@
  - [stencila-action-menu](../actionMenu)
  - [stencila-code-chunk](../codeChunk)
  - [stencila-code-expression](../codeExpression)
+ - [stencila-code-fragment](../codeFragment)
  - [stencila-executable-document-toolbar](../executableDocumentToolbar)
  - [stencila-toast](../toast)
 
@@ -49,6 +50,7 @@ graph TD;
   stencila-action-menu --> stencila-button
   stencila-code-chunk --> stencila-button
   stencila-code-expression --> stencila-button
+  stencila-code-fragment --> stencila-button
   stencila-executable-document-toolbar --> stencila-button
   stencila-toast --> stencila-button
   style stencila-button fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/components/src/components/codeBlock/codeBlock.css
+++ b/packages/components/src/components/codeBlock/codeBlock.css
@@ -1,0 +1,1 @@
+@import '~@stencila/style-stencila/dist/molecules/codeBlock.css';

--- a/packages/components/src/components/codeBlock/codeBlock.material.css
+++ b/packages/components/src/components/codeBlock/codeBlock.material.css
@@ -1,0 +1,1 @@
+@import '~@stencila/style-stencila/dist/molecules/codeBlock.css';

--- a/packages/components/src/components/codeBlock/codeBlock.tsx
+++ b/packages/components/src/components/codeBlock/codeBlock.tsx
@@ -1,0 +1,147 @@
+import { Component, Element, h, Host, Method, Prop } from '@stencil/core'
+import { CodeBlock, codeBlock } from '@stencila/schema'
+import { Keymap } from '../editor/editor'
+import {
+  FileFormat,
+  FileFormatMap,
+  lookupFormat,
+} from '../editor/languageUtils'
+
+/**
+ * @slot text - The source code of the `CodeChunk`. Corresponds to the `text` field in the Stencila `CodeChunk` Schema.
+ * @slot label - `label` element label of the `CodeChunk`. Corresponds to the `label` field in the Stencila `CodeChunk` Schema.
+ * @slot caption - `figcaption` content of the `CodeChunk`. Corresponds to the `caption` field in the Stencila `CodeChunk` Schema.
+ */
+@Component({
+  tag: 'stencila-code-block',
+  styleUrls: {
+    default: 'codeBlock.css',
+    material: 'codeBlock.material.css',
+  },
+  scoped: true,
+})
+export class CodeBlockComponent {
+  private static readonly slots = {
+    text: 'text',
+    outputs: 'outputs',
+    errors: 'errors',
+    caption: 'caption',
+    label: 'label',
+  }
+
+  @Element() private el: HTMLStencilaCodeBlockElement
+
+  private editorRef: HTMLStencilaEditorElement | null
+
+  /**
+   * Autofocus the editor on page load
+   */
+  @Prop() public autofocus = false
+
+  /**
+   * Control line wrapping of text inside the editor
+   */
+  @Prop()
+  public lineWrapping = false
+
+  /**
+   * Determines the visibility of line numbers
+   */
+  @Prop()
+  public lineNumbers = true
+
+  /**
+   * Enables ability to fold sections of code if the syntax package supports it
+   */
+  @Prop()
+  public foldGutter = true
+
+  /**
+   * Programming language of the CodeChunk
+   */
+  @Prop({ mutable: true })
+  public programmingLanguage: string | undefined
+
+  /**
+   * Disallow editing of the editor contents when set to `true`
+   */
+  @Prop()
+  public readOnly = false
+
+  /**
+   * List of programming languages that can be executed in the current context
+   */
+  @Prop()
+  public executableLanguages: FileFormatMap = {}
+
+  /**
+   * Custom keyboard shortcuts to pass along to CodeMirror
+   * @see https://codemirror.net/6/docs/ref/#keymap
+   */
+  @Prop() public keymap: Keymap[] = []
+
+  /**
+   * Listen for the `stencila-language-change` event emitted by the language dropdown
+   * provided by the child Editor component, and update the active language if necessary.
+   */
+  private handleLanguageChange = (e: CustomEvent<FileFormat>) => {
+    if (
+      this.programmingLanguage === undefined ||
+      lookupFormat(this.programmingLanguage).name !== e.detail.name
+    ) {
+      this.programmingLanguage = e.detail.name
+    }
+  }
+
+  componentDidLoad(): void {
+    this.editorRef = this.el.querySelector('stencila-editor')
+  }
+
+  /**
+   * Returns the `CodeChunk` node with the updated `text` content from the editor.
+   */
+  @Method()
+  public async getContents(): Promise<CodeBlock> {
+    if (this.editorRef) {
+      const { text, language } = await this.editorRef?.getContents()
+      return codeBlock({ text, programmingLanguage: language })
+    }
+
+    throw new Error('Could not get CodeChunk contents')
+  }
+
+  public render(): HTMLElement {
+    return (
+      <Host>
+        <figure>
+          <div>
+            <div
+              class={{
+                editorContainer: true,
+              }}
+            >
+              <stencila-editor
+                activeLanguage={this.programmingLanguage}
+                executableLanguages={this.executableLanguages}
+                autofocus={this.autofocus}
+                keymap={this.keymap}
+                readOnly={this.readOnly}
+                onStencila-language-change={this.handleLanguageChange}
+                foldGutter={this.foldGutter}
+                lineNumbers={this.lineNumbers}
+                lineWrapping={this.lineWrapping}
+              >
+                <slot name={CodeBlockComponent.slots.text} />
+                <slot name={CodeBlockComponent.slots.errors} />
+              </stencila-editor>
+            </div>
+          </div>
+
+          <slot name={CodeBlockComponent.slots.label} />
+
+          <slot name={CodeBlockComponent.slots.caption} />
+        </figure>
+      </Host>
+    )
+  }
+}

--- a/packages/components/src/components/codeBlock/readme.md
+++ b/packages/components/src/components/codeBlock/readme.md
@@ -1,0 +1,66 @@
+# stencila-code-block
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property              | Attribute              | Description                                                                | Type                           | Default     |
+| --------------------- | ---------------------- | -------------------------------------------------------------------------- | ------------------------------ | ----------- |
+| `autofocus`           | `autofocus`            | Autofocus the editor on page load                                          | `boolean`                      | `false`     |
+| `executableLanguages` | --                     | List of programming languages that can be executed in the current context  | `{ [x: string]: FileFormat; }` | `{}`        |
+| `foldGutter`          | `fold-gutter`          | Enables ability to fold sections of code if the syntax package supports it | `boolean`                      | `true`      |
+| `keymap`              | --                     | Custom keyboard shortcuts to pass along to CodeMirror                      | `KeyBinding[]`                 | `[]`        |
+| `lineNumbers`         | `line-numbers`         | Determines the visibility of line numbers                                  | `boolean`                      | `true`      |
+| `lineWrapping`        | `line-wrapping`        | Control line wrapping of text inside the editor                            | `boolean`                      | `false`     |
+| `programmingLanguage` | `programming-language` | Programming language of the CodeChunk                                      | `string \| undefined`          | `undefined` |
+| `readOnly`            | `read-only`            | Disallow editing of the editor contents when set to `true`                 | `boolean`                      | `false`     |
+
+
+## Methods
+
+### `getContents() => Promise<CodeBlock>`
+
+Returns the `CodeChunk` node with the updated `text` content from the editor.
+
+#### Returns
+
+Type: `Promise<CodeBlock>`
+
+
+
+
+## Slots
+
+| Slot        | Description                                                                                                     |
+| ----------- | --------------------------------------------------------------------------------------------------------------- |
+| `"caption"` | `figcaption` content of the `CodeChunk`. Corresponds to the `caption` field in the Stencila `CodeChunk` Schema. |
+| `"label"`   | `label` element label of the `CodeChunk`. Corresponds to the `label` field in the Stencila `CodeChunk` Schema.  |
+| `"text"`    | The source code of the `CodeChunk`. Corresponds to the `text` field in the Stencila `CodeChunk` Schema.         |
+
+
+## CSS Custom Properties
+
+| Name                  | Description                                                            |
+| --------------------- | ---------------------------------------------------------------------- |
+| `--background-editor` | Background color of the Code Editor section                            |
+| `--border`            | Border color around the component as well as internal section dividers |
+
+
+## Dependencies
+
+### Depends on
+
+- [stencila-editor](../editor)
+
+### Graph
+```mermaid
+graph TD;
+  stencila-code-block --> stencila-editor
+  stencila-editor --> stencila-icon
+  style stencila-code-block fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/components/src/components/codeExpression/codeExpression.tsx
+++ b/packages/components/src/components/codeExpression/codeExpression.tsx
@@ -51,6 +51,12 @@ export class CodeExpressionComponent implements CodeComponent<CodeExpression> {
   ) => Promise<CodeExpression>
 
   /**
+   * Disallow editing of the editor contents when set to `true`
+   */
+  @Prop()
+  public readOnly = false
+
+  /**
    * Programming language of the CodeExpression
    */
   @Prop({ mutable: true })
@@ -264,12 +270,12 @@ export class CodeExpressionComponent implements CodeComponent<CodeExpression> {
             activeLanguage={this.programmingLanguage ?? ''}
             onSetLanguage={this.onSelectLanguage}
             executableLanguages={FileFormatUtils.fileFormatMap}
-            setRef={() => {}}
+            disabled={this.readOnly}
           ></LanguagePickerInline>
         </span>
         <span
           class="text"
-          contentEditable={true}
+          contentEditable={!this.readOnly}
           onBlur={this.removeHoverState}
           tabIndex={this.isCodeVisible ? 0 : -1}
           role="textbox"

--- a/packages/components/src/components/codeExpression/languageSelect.tsx
+++ b/packages/components/src/components/codeExpression/languageSelect.tsx
@@ -1,0 +1,69 @@
+import { FunctionalComponent, h } from '@stencil/core'
+import { FileFormatMap, lookupFormat } from '../editor/languageUtils'
+
+interface Props {
+  activeLanguage: string
+  disabled: boolean
+  languageCapabilities?: FileFormatMap
+  executableLanguages?: FileFormatMap
+  onSetLanguage?: (language: string) => void
+  setRef?: (el?: HTMLSelectElement) => void
+}
+
+export const LanguagePickerInline = (props: Props): FunctionalComponent => {
+  const activeLanguageByAlias = lookupFormat(props.activeLanguage)
+
+  const hasExecutableLanguages =
+    Object.keys(props.executableLanguages ?? {}).length > 0
+
+  const filteredLanguages = hasExecutableLanguages
+    ? Object.entries(props.languageCapabilities ?? {}).reduce(
+        (langs: FileFormatMap, [name, details]) => {
+          return Object.keys(props.executableLanguages ?? {}).includes(name)
+            ? langs
+            : { ...langs, [name]: details }
+        },
+        {}
+      )
+    : props.languageCapabilities ?? {}
+
+  return (
+    <stencila-menu aria-label="Programming Language" autoClose={true}>
+      <stencila-button
+        iconOnly={true}
+        icon="terminal"
+        size="xsmall"
+        slot="toggle"
+        aria-label="Toggle menu"
+        color="key"
+        minimal={true}
+        tooltip={`${activeLanguageByAlias.name}`}
+        disabled={props.disabled}
+      ></stencila-button>
+
+      {hasExecutableLanguages &&
+        Object.values(props.executableLanguages ?? {}).map((language) => (
+          <stencila-menu-item
+            size="xsmall"
+            onClick={() => props.onSetLanguage?.(language.name)}
+            icon={
+              language.name === activeLanguageByAlias.name ? 'check' : undefined
+            }
+          >
+            {language.name}
+          </stencila-menu-item>
+        ))}
+
+      <option disabled>Non-executable</option>
+
+      {Object.values(filteredLanguages).map((language) => (
+        <stencila-menu-item
+          size="xsmall"
+          onClick={() => props.onSetLanguage?.(language.name)}
+        >
+          {language.name}
+        </stencila-menu-item>
+      ))}
+    </stencila-menu>
+  )
+}

--- a/packages/components/src/components/codeExpression/readme.md
+++ b/packages/components/src/components/codeExpression/readme.md
@@ -10,6 +10,7 @@
 | `codeExpression`      | --                     | Stencila CodeExpression node to render                                                                            | `CodeExpression \| undefined`                                                | `undefined` |
 | `executeHandler`      | --                     | A callback function to be called with the value of the `CodeExpression` node when executing the `CodeExpression`. | `((codeExpression: CodeExpression) => Promise<CodeExpression>) \| undefined` | `undefined` |
 | `programmingLanguage` | `programming-language` | Programming language of the CodeExpression                                                                        | `string`                                                                     | `undefined` |
+| `readOnly`            | `read-only`            | Disallow editing of the editor contents when set to `true`                                                        | `boolean`                                                                    | `false`     |
 
 
 ## Events

--- a/packages/components/src/components/codeExpression/readme.md
+++ b/packages/components/src/components/codeExpression/readme.md
@@ -12,6 +12,13 @@
 | `programmingLanguage` | `programming-language` | Programming language of the CodeExpression                                                                        | `string`                                                                     | `undefined` |
 
 
+## Events
+
+| Event                      | Description                                               | Type                                                                     |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `stencila-language-change` | Event emitted when the language of the editor is changed. | `CustomEvent<{ name: string; ext: string \| null; aliases: string[]; }>` |
+
+
 ## Methods
 
 ### `execute() => Promise<CodeExpression>`
@@ -59,15 +66,20 @@ Type: `Promise<CodeExpression>`
 
 - [stencila-button](../button)
 - [stencila-tooltip](../tooltip)
+- [stencila-menu](../menu)
+- [stencila-menu-item](../menuItem)
 
 ### Graph
 ```mermaid
 graph TD;
   stencila-code-expression --> stencila-button
   stencila-code-expression --> stencila-tooltip
+  stencila-code-expression --> stencila-menu
+  stencila-code-expression --> stencila-menu-item
   stencila-button --> stencila-icon
   stencila-button --> stencila-tooltip
   stencila-tooltip --> stencila-tooltip-element
+  stencila-menu-item --> stencila-icon
   style stencila-code-expression fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/components/src/components/codeFragment/codeFragment.css
+++ b/packages/components/src/components/codeFragment/codeFragment.css
@@ -1,0 +1,1 @@
+@import '~@stencila/style-stencila/dist/molecules/codeFragment.css';

--- a/packages/components/src/components/codeFragment/codeFragment.tsx
+++ b/packages/components/src/components/codeFragment/codeFragment.tsx
@@ -1,0 +1,62 @@
+import { Component, h, Host, Event, Prop, EventEmitter } from '@stencil/core'
+import { FileFormatUtils } from '../..'
+import { LanguagePickerInline } from '../codeExpression/languageSelect'
+import { FileFormat, lookupFormat } from '../editor/languageUtils'
+
+/**
+ * @slot default - The contents of the code fragment
+ */
+@Component({
+  tag: 'stencila-code-fragment',
+  styleUrls: {
+    default: 'codeFragment.css',
+    material: 'codeFragment.css',
+  },
+  scoped: true,
+})
+export class CodeFragment {
+  /**
+   * Disallow editing of the editor contents when set to `true`
+   */
+  @Prop()
+  public readOnly = false
+
+  /**
+   * Programming language of the CodeFragment
+   */
+  @Prop({ mutable: true })
+  public programmingLanguage: string | undefined
+
+  /**
+   * Event emitted when the language of the editor is changed.
+   */
+  @Event({ eventName: 'stencila-language-change' })
+  languageChange: EventEmitter<FileFormat>
+
+  /**
+   * Function to call when the user selects a new language from the language picker dropdown.
+   */
+  private onSelectLanguage = async (language: string): Promise<void> => {
+    this.languageChange.emit(lookupFormat(language))
+    this.programmingLanguage = language
+  }
+
+  public render() {
+    return (
+      <Host class="text">
+        <span class="actionsSecondary">
+          <LanguagePickerInline
+            activeLanguage={this.programmingLanguage ?? ''}
+            onSetLanguage={this.onSelectLanguage}
+            executableLanguages={FileFormatUtils.fileFormatMap}
+            disabled={this.readOnly}
+          ></LanguagePickerInline>
+        </span>
+
+        <span class="text">
+          <slot />
+        </span>
+      </Host>
+    )
+  }
+}

--- a/packages/components/src/components/codeFragment/readme.md
+++ b/packages/components/src/components/codeFragment/readme.md
@@ -1,0 +1,60 @@
+# stencila-code-fragment
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property              | Attribute              | Description                                                | Type                  | Default     |
+| --------------------- | ---------------------- | ---------------------------------------------------------- | --------------------- | ----------- |
+| `programmingLanguage` | `programming-language` | Programming language of the CodeFragment                   | `string \| undefined` | `undefined` |
+| `readOnly`            | `read-only`            | Disallow editing of the editor contents when set to `true` | `boolean`             | `false`     |
+
+
+## Events
+
+| Event                      | Description                                               | Type                                                                     |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `stencila-language-change` | Event emitted when the language of the editor is changed. | `CustomEvent<{ name: string; ext: string \| null; aliases: string[]; }>` |
+
+
+## Slots
+
+| Slot        | Description                       |
+| ----------- | --------------------------------- |
+| `"default"` | The contents of the code fragment |
+
+
+## CSS Custom Properties
+
+| Name                   | Description                                                            |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `--background`         | Background color of the Code Fragment                                  |
+| `--background-buttons` | Background color of the Code Editor section                            |
+| `--border`             | Border color around the component as well as internal section dividers |
+
+
+## Dependencies
+
+### Depends on
+
+- [stencila-menu](../menu)
+- [stencila-button](../button)
+- [stencila-menu-item](../menuItem)
+
+### Graph
+```mermaid
+graph TD;
+  stencila-code-fragment --> stencila-menu
+  stencila-code-fragment --> stencila-button
+  stencila-code-fragment --> stencila-menu-item
+  stencila-button --> stencila-icon
+  stencila-button --> stencila-tooltip
+  stencila-tooltip --> stencila-tooltip-element
+  stencila-menu-item --> stencila-icon
+  style stencila-code-fragment fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/components/src/components/editor/components/languageSelect.tsx
+++ b/packages/components/src/components/editor/components/languageSelect.tsx
@@ -3,6 +3,7 @@ import { FileFormatMap, lookupFormat } from '../languageUtils'
 
 interface Props {
   activeLanguage: string
+  disabled: boolean
   languageCapabilities: FileFormatMap
   executableLanguages: FileFormatMap
   onSetLanguage: (e: Event) => void
@@ -28,7 +29,11 @@ export const LanguagePicker = (props: Props): FunctionalComponent => {
   return (
     <label aria-label="Programming Language">
       <stencila-icon icon="terminal"></stencila-icon>
-      <select onChange={props.onSetLanguage} ref={props.setRef}>
+      <select
+        onChange={props.onSetLanguage}
+        ref={props.setRef}
+        disabled={props.disabled}
+      >
         {hasExecutableLanguages &&
           Object.values(props.executableLanguages).map((language) => (
             <option

--- a/packages/components/src/components/editor/editor.tsx
+++ b/packages/components/src/components/editor/editor.tsx
@@ -679,6 +679,7 @@ export class Editor {
           <menu>
             <LanguagePicker
               activeLanguage={this.activeLanguage}
+              disabled={this.readOnly}
               onSetLanguage={this.onSelectLanguage}
               languageCapabilities={this.languageCapabilities}
               executableLanguages={this.executableLanguages}

--- a/packages/components/src/components/editor/editor.tsx
+++ b/packages/components/src/components/editor/editor.tsx
@@ -225,6 +225,10 @@ export class Editor {
         const { javascript } = await import('@codemirror/lang-javascript')
         return javascript()
       }
+      case 'typescript': {
+        const { javascript } = await import('@codemirror/lang-javascript')
+        return javascript({ typescript: true })
+      }
       case 'json': {
         const { json } = await import('@codemirror/lang-json')
         return json()

--- a/packages/components/src/components/editor/languageUtils.ts
+++ b/packages/components/src/components/editor/languageUtils.ts
@@ -72,6 +72,11 @@ export const fileFormatMap: FileFormatMap = {
     ext: 'toml',
     aliases: ['toml'],
   },
+  TypeScript: {
+    name: 'TypeScript',
+    ext: 'ts',
+    aliases: ['typescript', 'ts'],
+  },
   XML: {
     name: 'XML',
     ext: 'xml',

--- a/packages/components/src/components/editor/readme.md
+++ b/packages/components/src/components/editor/readme.md
@@ -114,6 +114,7 @@ Type: `Promise<void>`
 
 ### Used by
 
+ - [stencila-code-block](../codeBlock)
  - [stencila-code-chunk](../codeChunk)
 
 ### Depends on
@@ -124,6 +125,7 @@ Type: `Promise<void>`
 ```mermaid
 graph TD;
   stencila-editor --> stencila-icon
+  stencila-code-block --> stencila-editor
   stencila-code-chunk --> stencila-editor
   style stencila-editor fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/components/src/components/menu/menu.tsx
+++ b/packages/components/src/components/menu/menu.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, Prop } from '@stencil/core'
+import { Component, Element, h, Host, Prop } from '@stencil/core'
 
 let menuIds = 0
 
@@ -11,6 +11,8 @@ let menuIds = 0
   scoped: true,
 })
 export class Menu {
+  @Element() private el: HTMLStencilaCodeFragmentElement
+
   /**
    * Determines whether the Menu is shown or not
    */
@@ -20,12 +22,40 @@ export class Menu {
   })
   public isOpen = false
 
+  /**
+   * Close the menu when losing focus
+   */
+  @Prop()
+  public autoClose = false
+
   private toggleMenu = (e: MouseEvent) => {
     e.preventDefault()
     this.isOpen = !this.isOpen
   }
 
+  private closeMenu = () => {
+    this.isOpen = false
+  }
+
+  private autoCloseTimeoutRef: number
+  private closeOnBlur = (e: MouseEvent) => {
+    if (this.isOpen && !this.el.contains(e.relatedTarget as Node)) {
+      this.autoCloseTimeoutRef = window.setTimeout(this.closeMenu, 250)
+    }
+  }
+
+  private clearTimeout = () => {
+    window.clearTimeout(this.autoCloseTimeoutRef)
+  }
+
   private menuId = `stencila-menu-${menuIds++}`
+
+  componentWillLoad() {
+    if (this.autoClose) {
+      this.el.addEventListener('mouseout', this.closeOnBlur)
+      this.el.addEventListener('mouseenter', this.clearTimeout)
+    }
+  }
 
   public render() {
     return (
@@ -44,6 +74,7 @@ export class Menu {
           aria-orientation="vertical"
           tabindex="-1"
           id={this.menuId}
+          onClick={this.closeMenu}
         >
           <slot />
         </ul>

--- a/packages/components/src/components/menu/readme.md
+++ b/packages/components/src/components/menu/readme.md
@@ -5,10 +5,26 @@
 
 ## Properties
 
-| Property | Attribute | Description                                 | Type      | Default |
-| -------- | --------- | ------------------------------------------- | --------- | ------- |
-| `isOpen` | `is-open` | Determines whether the Menu is shown or not | `boolean` | `false` |
+| Property    | Attribute    | Description                                 | Type      | Default |
+| ----------- | ------------ | ------------------------------------------- | --------- | ------- |
+| `autoClose` | `auto-close` | Close the menu when losing focus            | `boolean` | `false` |
+| `isOpen`    | `is-open`    | Determines whether the Menu is shown or not | `boolean` | `false` |
 
+
+## Dependencies
+
+### Used by
+
+ - [stencila-code-expression](../codeExpression)
+ - [stencila-code-fragment](../codeFragment)
+
+### Graph
+```mermaid
+graph TD;
+  stencila-code-expression --> stencila-menu
+  stencila-code-fragment --> stencila-menu
+  style stencila-menu fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/packages/components/src/components/menuItem/menuItem.tsx
+++ b/packages/components/src/components/menuItem/menuItem.tsx
@@ -17,9 +17,14 @@ export class MenuItem {
   @Prop()
   icon: IconNames | undefined
 
+  /**
+   * The overall size of the component.
+   */
+  @Prop() public size: 'xsmall' | 'small' | 'default' | 'large' = 'default'
+
   public render() {
     return (
-      <Host role="menuitem">
+      <Host role="menuitem" size={this.size}>
         {this.icon !== undefined && (
           <stencila-icon icon={this.icon}></stencila-icon>
         )}

--- a/packages/components/src/components/menuItem/readme.md
+++ b/packages/components/src/components/menuItem/readme.md
@@ -5,12 +5,18 @@
 
 ## Properties
 
-| Property | Attribute | Description                               | Type                     | Default     |
-| -------- | --------- | ----------------------------------------- | ------------------------ | ----------- |
-| `icon`   | `icon`    | Name of the icon to show before the label | `IconNames \| undefined` | `undefined` |
+| Property | Attribute | Description                               | Type                                          | Default     |
+| -------- | --------- | ----------------------------------------- | --------------------------------------------- | ----------- |
+| `icon`   | `icon`    | Name of the icon to show before the label | `IconNames \| undefined`                      | `undefined` |
+| `size`   | `size`    | The overall size of the component.        | `"default" \| "large" \| "small" \| "xsmall"` | `'default'` |
 
 
 ## Dependencies
+
+### Used by
+
+ - [stencila-code-expression](../codeExpression)
+ - [stencila-code-fragment](../codeFragment)
 
 ### Depends on
 
@@ -20,6 +26,8 @@
 ```mermaid
 graph TD;
   stencila-menu-item --> stencila-icon
+  stencila-code-expression --> stencila-menu-item
+  stencila-code-fragment --> stencila-menu-item
   style stencila-menu-item fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/style-material/src/atoms/menuItem.css
+++ b/packages/style-material/src/atoms/menuItem.css
@@ -8,4 +8,16 @@
   stencila-icon {
     @apply mr-2;
   }
+
+  &[size='xsmall'] {
+    @apply h-5 text-xs;
+
+    stencila-icon {
+      @apply mr-1;
+    }
+  }
+
+  &[size='sm'] {
+    @apply h-6 text-base;
+  }
 }

--- a/packages/style-stencila/src/atoms/menuItem.css
+++ b/packages/style-stencila/src/atoms/menuItem.css
@@ -1,5 +1,5 @@
 :host {
-  @apply flex items-center h-8 px-2 text-sm leading-none tracking-wide no-underline uppercase cursor-pointer font-body text-key;
+  @apply flex items-center h-8 px-2 text-sm leading-none tracking-wide no-underline cursor-pointer font-body text-key;
 
   &:hover {
     @apply bg-neutral-50;
@@ -7,5 +7,17 @@
 
   stencila-icon {
     @apply mr-2;
+  }
+
+  &[size='xsmall'] {
+    @apply h-5 text-xs;
+
+    stencila-icon {
+      @apply mr-1;
+    }
+  }
+
+  &[size='sm'] {
+    @apply h-6 text-base;
   }
 }

--- a/packages/style-stencila/src/molecules/codeBlock.css
+++ b/packages/style-stencila/src/molecules/codeBlock.css
@@ -1,0 +1,40 @@
+@import '../base.css';
+@import '../atoms/code.css';
+@import '../atoms/pre.css';
+
+.preReset {
+  @apply p-0 m-0 border-0;
+}
+
+:host,
+stencila-code-block {
+  /** @prop --background-editor: Background color of the Code Editor section */
+  --background-editor: var(--color-neutral-50, #edf2f7);
+
+  /** @prop --border: Border color around the component as well as internal section dividers */
+  --border: var(--color-neutral-100, #e2e8f0);
+
+  @apply relative block w-full my-4 overflow-hidden border border-solid rounded;
+  border-color: var(--border);
+
+  & > figure {
+    @apply m-0 p-0;
+  }
+
+  stencila-editor {
+    --border-width: 0;
+    @apply flex-grow;
+  }
+}
+
+.editorContainer {
+  @apply relative flex flex-col flex-auto m-0 border-t-0 border-b border-l-0 border-r-0 rounded-none;
+  background: var(--background-editor);
+  border-color: var(--border);
+  height: intrinsic;
+
+  pre,
+  pre[class*='language-'] {
+    @apply bg-transparent;
+  }
+}

--- a/packages/style-stencila/src/molecules/codeExpression.css
+++ b/packages/style-stencila/src/molecules/codeExpression.css
@@ -77,10 +77,10 @@ stencila-code-expression {
   .actions stencila-button {
     @apply inline-flex items-stretch self-start flex-shrink-0 overflow-hidden cursor-default transition ease-out duration-150;
     transition-property: padding, width, max-width;
+  }
 
-    &.sourceToggle {
-      @apply inline-block w-0;
-    }
+  .actions .secondaryAction {
+    @apply inline-block w-0 overflow-hidden cursor-default transition ease-out duration-150;
   }
 
   &.isOutputEmpty {
@@ -96,8 +96,8 @@ stencila-code-expression {
   &:focus,
   &:focus-within,
   &:hover {
-    .actions stencila-button.sourceToggle {
-      @apply inline-flex w-8 max-w-full;
+    .actions .secondaryAction {
+      @apply inline-flex w-5 max-w-full;
     }
   }
 }

--- a/packages/style-stencila/src/molecules/codeFragment.css
+++ b/packages/style-stencila/src/molecules/codeFragment.css
@@ -1,0 +1,34 @@
+:host,
+stencila-code-fragment {
+  /** @prop --background: Background color of the Code Fragment */
+  --background: var(--color-stock, #fff);
+
+  /** @prop --background-buttons: Background color of the Code Editor section */
+  --background-buttons: var(--color-neutral-50, #edf2f7);
+
+  /** @prop --border: Border color around the component as well as internal section dividers */
+  --border: var(--color-neutral-100, #e2e8f0);
+
+  @apply inline-flex text-sm p-0 leading-none whitespace-nowrap align-text-bottom text-key border border-solid rounded;
+  background-color: var(--background);
+  border-color: var(--border);
+
+  .actionsSecondary {
+    @apply inline-block w-0 overflow-hidden cursor-default transition ease-out duration-150;
+    background-color: var(--background-buttons);
+  }
+
+  &.hover,
+  &:focus,
+  &:focus-within,
+  &:hover {
+    .actionsSecondary {
+      @apply inline-flex w-5 max-w-full;
+    }
+  }
+
+  .text {
+    @apply p-1;
+    background-color: var(--background-editor);
+  }
+}

--- a/stories/molecules/codeBlock/codeBlock.stories.js
+++ b/stories/molecules/codeBlock/codeBlock.stories.js
@@ -1,0 +1,42 @@
+import { html } from 'lit-html'
+
+export default {
+  title: 'Schema Nodes/Code Block',
+  component: 'stencila-code-block',
+}
+
+export const codeBlock = ({
+  activeLanguage,
+  lineNumbers,
+  lineWrapping,
+  readOnly,
+  foldGutter,
+  executableLanguages,
+}) => html`
+  <stencila-code-block
+    .activeLanguage=${activeLanguage}
+    .lineNumbers=${lineNumbers}
+    .lineWrapping=${lineWrapping}
+    .foldGutter=${foldGutter}
+    .readOnly=${readOnly}
+    .executableLanguages=${executableLanguages}
+  >
+    <pre slot="text">
+<code>Code with no language</code></pre>
+  </stencila-code-block>
+
+  <stencila-code-block
+    programming-language="python"
+    .activeLanguage=${activeLanguage}
+    .lineNumbers=${lineNumbers}
+    .lineWrapping=${lineWrapping}
+    .foldGutter=${foldGutter}
+    .readOnly=${readOnly}
+    .executableLanguages=${executableLanguages}
+  >
+    <meta itemprop="programmingLanguage" content="python" />
+    <pre slot="text">
+<code itemprop="text" class="language-python"># Some Python code
+1 + 1</code></pre>
+  </stencila-code-block>
+`

--- a/stories/molecules/codeFragment/codeFragment.stories.js
+++ b/stories/molecules/codeFragment/codeFragment.stories.js
@@ -1,0 +1,33 @@
+import { html } from 'lit-html'
+
+export default {
+  title: 'Schema Nodes/Code Fragment',
+  component: 'stencila-code-fragment',
+}
+
+export const codeFragment = () => html`
+  <div>
+    <p>
+      <span>Some</span>
+      <stencila-code-fragment>
+        <code itemtype="http://schema.stenci.la/CodeFragment" itemscope
+          >code</code
+        >
+      </stencila-code-fragment>
+      <span>in a paragraph.</span>
+    </p>
+    <p>
+      <span>With a language</span>
+      <stencila-code-fragment programming-language="python">
+        <code
+          itemtype="http://schema.stenci.la/CodeFragment"
+          itemscope
+          class="language-python"
+        >
+          <meta itemprop="programmingLanguage" content="python" />1 + 1</code
+        >
+      </stencila-code-fragment>
+      <span>specified.</span>
+    </p>
+  </div>
+`

--- a/stories/molecules/codeFragment/codeFragment.stories.js
+++ b/stories/molecules/codeFragment/codeFragment.stories.js
@@ -18,7 +18,7 @@ export const codeFragment = () => html`
     </p>
     <p>
       <span>With a language</span>
-      <stencila-code-fragment programming-language="python">
+      <stencila-code-fragment programming-language="python" .readOnly=${true}>
         <code
           itemtype="http://schema.stenci.la/CodeFragment"
           itemscope


### PR DESCRIPTION
This PR adds a `stencila-code-fragment` and `stencila-code-block` components (Closes #245, closes #246).

This PR also:
- exposes and allows setting the programming language of CodeFragment and CodeExpression components
- Adds support for `readOnly` mode for all code components. Disabling the editing of the code content, as well as changing of the programming language
- Adds TypeScript syntax support for the Editor component