### PR TITLE
fix(Code): Ensure code components have unified interfaces and methods

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -123,6 +123,10 @@ export namespace Components {
          */
         "getRef": () => Promise<EditorView | undefined>;
         /**
+          * Returns the text contents from the editor
+         */
+        "getTextContents": () => Promise<string>;
+        /**
           * Custom keyboard shortcuts to pass along to CodeMirror
           * @see https://codemirror.net/6/docs/ref/#keymap
          */
@@ -182,6 +186,10 @@ export namespace Components {
          */
         "getRef": () => Promise<EditorView | undefined>;
         /**
+          * Returns the text contents from the editor
+         */
+        "getTextContents": () => Promise<string>;
+        /**
           * Whether the code section is visible or not
          */
         "isCodeVisible": boolean;
@@ -234,6 +242,10 @@ export namespace Components {
          */
         "getContents": () => Promise<CodeExpression>;
         /**
+          * Returns the text contents from the inline code editor
+         */
+        "getTextContents": () => Promise<string>;
+        /**
           * List of all supported programming languages
          */
         "languageCapabilities": FileFormatMap;
@@ -252,17 +264,21 @@ export namespace Components {
          */
         "executableLanguages": FileFormatMap;
         /**
+          * Returns the text contents from the inline code editor
+         */
+        "getTextContents": () => Promise<string>;
+        /**
           * List of all supported programming languages
          */
         "languageCapabilities": FileFormatMap;
         /**
+          * The context of the component. In `read` mode the code content and its language cannot be edited.
+         */
+        "mode": 'read' | 'edit';
+        /**
           * Programming language of the CodeFragment
          */
         "programmingLanguage": string | undefined;
-        /**
-          * Disallow editing of the editor contents when set to `true`
-         */
-        "readOnly": boolean;
     }
     interface StencilaDataTable {
     }
@@ -969,6 +985,10 @@ declare namespace LocalJSX {
          */
         "languageCapabilities"?: FileFormatMap;
         /**
+          * Event emitted when the source code of the `CodeExpression` node is changed.
+         */
+        "onStencila-content-change"?: (event: CustomEvent<string>) => void;
+        /**
           * Event emitted when the language of the editor is changed.
          */
         "onStencila-language-change"?: (event: CustomEvent<FileFormat>) => void;
@@ -991,6 +1011,14 @@ declare namespace LocalJSX {
          */
         "languageCapabilities"?: FileFormatMap;
         /**
+          * The context of the component. In `read` mode the code content and its language cannot be edited.
+         */
+        "mode"?: 'read' | 'edit';
+        /**
+          * Event emitted when the source code of the `CodeExpression` node is changed.
+         */
+        "onStencila-content-change"?: (event: CustomEvent<string>) => void;
+        /**
           * Event emitted when the language of the editor is changed.
          */
         "onStencila-language-change"?: (event: CustomEvent<FileFormat>) => void;
@@ -998,10 +1026,6 @@ declare namespace LocalJSX {
           * Programming language of the CodeFragment
          */
         "programmingLanguage"?: string | undefined;
-        /**
-          * Disallow editing of the editor contents when set to `true`
-         */
-        "readOnly"?: boolean;
     }
     interface StencilaDataTable {
     }

--- a/packages/components/src/components/code/codeTypes.ts
+++ b/packages/components/src/components/code/codeTypes.ts
@@ -1,16 +1,87 @@
-import { CodeChunk, CodeExpression } from '@stencila/schema'
+import { EventEmitter } from '@stencil/core'
+import {
+  Code,
+  CodeBlock,
+  CodeChunk,
+  CodeExpression,
+  CodeFragment,
+} from '@stencila/schema'
+import { FileFormat, FileFormatMap } from '../editor/languageUtils'
 
 export type CodeVisibilityEvent = CustomEvent<{
   isVisible: boolean
 }>
 
+export type DiscoverExecutableLanguagesEvent = CustomEvent<{
+  languages: FileFormatMap
+}>
+
 // Defines a set of methods and properties that all `Code` node based components
 // must implement to ensure a unified public API and interactions
-export abstract class CodeComponent<C extends CodeChunk | CodeExpression> {
-  abstract onAllCodeVisibilityChange(event: CodeVisibilityEvent): void
-
+abstract class SharedCodeInterface<C extends Code> {
+  // Props
   executeHandler?: (code: C) => Promise<C>
+
+  // Methods
+  abstract getTextContents(): Promise<string>
+
+  // Event Listeners
+  // `stencila-discover-executable-languages`
+  abstract onDiscoverExecutableLanguages(
+    event: DiscoverExecutableLanguagesEvent
+  ): void
+}
+
+// Ensure that Code components which have both `text` and `output` elements can toggle
+// visibility of the `code` part.
+abstract class ExecutableCodeComponent<C extends CodeChunk | CodeExpression> {
+  // Methods
   abstract execute: () => Promise<C>
 
+  // Event Listeners
+  // `stencila-code-visibility-change`
+  abstract onAllCodeVisibilityChange(event: CodeVisibilityEvent): void
+}
+
+/**
+ * Components which wrap `<stencila-editor>` component do not need to implement the
+ * following interfaces as they can be delegated to the editor component.
+ */
+export abstract class EditorCodeMethods {
+  // Event Emitters
+  abstract contentChange: EventEmitter<string>
+
+  // stencila-language-change
+  abstract languageChange: EventEmitter<FileFormat>
+}
+
+abstract class EditorBasedCodeComponent<
+  C extends CodeChunk | CodeBlock
+> extends SharedCodeInterface<C> {
+  // Methods
   abstract getContents(): Promise<C>
 }
+
+/**
+ * Inline code components which do not wrap `stencila-editor` components.
+ */
+abstract class NonEditorBasedCodeComponent<
+  C extends CodeFragment | CodeExpression
+> extends SharedCodeInterface<C> {
+  // Event Emitters
+  // `stencila-content-change`
+  abstract contentChange: EventEmitter<string>
+
+  // stencila-language-change
+  abstract languageChange: C extends CodeChunk ? void : EventEmitter<FileFormat>
+}
+
+export type CodeComponent<C extends Code> = C extends CodeChunk
+  ? EditorBasedCodeComponent<C> & ExecutableCodeComponent<C>
+  : C extends CodeExpression
+  ? NonEditorBasedCodeComponent<C> & ExecutableCodeComponent<C>
+  : C extends CodeBlock
+  ? EditorBasedCodeComponent<C>
+  : C extends CodeFragment
+  ? NonEditorBasedCodeComponent<C>
+  : never

--- a/packages/components/src/components/codeBlock/readme.md
+++ b/packages/components/src/components/codeBlock/readme.md
@@ -42,6 +42,16 @@ Type: `Promise<EditorView | undefined>`
 
 
 
+### `getTextContents() => Promise<string>`
+
+Returns the text contents from the editor
+
+#### Returns
+
+Type: `Promise<string>`
+
+
+
 
 ## Slots
 

--- a/packages/components/src/components/codeChunk/readme.md
+++ b/packages/components/src/components/codeChunk/readme.md
@@ -60,6 +60,16 @@ Type: `Promise<EditorView | undefined>`
 
 
 
+### `getTextContents() => Promise<string>`
+
+Returns the text contents from the editor
+
+#### Returns
+
+Type: `Promise<string>`
+
+
+
 
 ## Slots
 

--- a/packages/components/src/components/codeExpression/readme.md
+++ b/packages/components/src/components/codeExpression/readme.md
@@ -17,9 +17,10 @@
 
 ## Events
 
-| Event                      | Description                                               | Type                                                                     |
-| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `stencila-language-change` | Event emitted when the language of the editor is changed. | `CustomEvent<{ name: string; ext: string \| null; aliases: string[]; }>` |
+| Event                      | Description                                                                 | Type                                                                     |
+| -------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `stencila-content-change`  | Event emitted when the source code of the `CodeExpression` node is changed. | `CustomEvent<string>`                                                    |
+| `stencila-language-change` | Event emitted when the language of the editor is changed.                   | `CustomEvent<{ name: string; ext: string \| null; aliases: string[]; }>` |
 
 
 ## Methods
@@ -41,6 +42,16 @@ Returns the `CodeExpression` node with the updated `text` contents from the edit
 #### Returns
 
 Type: `Promise<CodeExpression>`
+
+
+
+### `getTextContents() => Promise<string>`
+
+Returns the text contents from the inline code editor
+
+#### Returns
+
+Type: `Promise<string>`
 
 
 

--- a/packages/components/src/components/codeFragment/readme.md
+++ b/packages/components/src/components/codeFragment/readme.md
@@ -5,19 +5,33 @@
 
 ## Properties
 
-| Property               | Attribute              | Description                                                               | Type                           | Default                                               |
-| ---------------------- | ---------------------- | ------------------------------------------------------------------------- | ------------------------------ | ----------------------------------------------------- |
-| `executableLanguages`  | --                     | List of programming languages that can be executed in the current context | `{ [x: string]: FileFormat; }` | `window.stencilaWebClient?.executableLanguages ?? {}` |
-| `languageCapabilities` | --                     | List of all supported programming languages                               | `{ [x: string]: FileFormat; }` | `fileFormatMap`                                       |
-| `programmingLanguage`  | `programming-language` | Programming language of the CodeFragment                                  | `string \| undefined`          | `undefined`                                           |
-| `readOnly`             | `read-only`            | Disallow editing of the editor contents when set to `true`                | `boolean`                      | `false`                                               |
+| Property               | Attribute              | Description                                                                                      | Type                           | Default                                               |
+| ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------ | ----------------------------------------------------- |
+| `executableLanguages`  | --                     | List of programming languages that can be executed in the current context                        | `{ [x: string]: FileFormat; }` | `window.stencilaWebClient?.executableLanguages ?? {}` |
+| `languageCapabilities` | --                     | List of all supported programming languages                                                      | `{ [x: string]: FileFormat; }` | `fileFormatMap`                                       |
+| `mode`                 | `mode`                 | The context of the component. In `read` mode the code content and its language cannot be edited. | `"edit" \| "read"`             | `'read'`                                              |
+| `programmingLanguage`  | `programming-language` | Programming language of the CodeFragment                                                         | `string \| undefined`          | `undefined`                                           |
 
 
 ## Events
 
-| Event                      | Description                                               | Type                                                                     |
-| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `stencila-language-change` | Event emitted when the language of the editor is changed. | `CustomEvent<{ name: string; ext: string \| null; aliases: string[]; }>` |
+| Event                      | Description                                                                 | Type                                                                     |
+| -------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `stencila-content-change`  | Event emitted when the source code of the `CodeExpression` node is changed. | `CustomEvent<string>`                                                    |
+| `stencila-language-change` | Event emitted when the language of the editor is changed.                   | `CustomEvent<{ name: string; ext: string \| null; aliases: string[]; }>` |
+
+
+## Methods
+
+### `getTextContents() => Promise<string>`
+
+Returns the text contents from the inline code editor
+
+#### Returns
+
+Type: `Promise<string>`
+
+
 
 
 ## Slots

--- a/packages/components/src/components/editor/editor.tsx
+++ b/packages/components/src/components/editor/editor.tsx
@@ -40,6 +40,7 @@ import {
   Prop,
   Watch,
 } from '@stencil/core'
+import { DiscoverExecutableLanguagesEvent } from '../code/codeTypes'
 import { getSlotByName } from '../utils/slotSelectors'
 import { LanguagePicker } from './components/languageSelect'
 import { codeErrors, updateErrors } from './customizations/errorPanel'
@@ -136,9 +137,9 @@ export class Editor {
     window.stencilaWebClient?.executableLanguages ?? {}
 
   @Listen('stencila-discover-executable-languages', { target: 'window' })
-  onDiscoverKernels({
+  onDiscoverExecutableLanguages({
     detail,
-  }: CustomEvent<{ languages: FileFormatMap }>): void {
+  }: DiscoverExecutableLanguagesEvent): void {
     this.executableLanguages = detail.languages
   }
 

--- a/packages/components/src/components/parameter/parameter.tsx
+++ b/packages/components/src/components/parameter/parameter.tsx
@@ -166,7 +166,7 @@ export class Parameter {
 
           <span
             class="name"
-            contenteditable={this.mode === 'edit'}
+            contentEditable={this.mode === 'edit'}
             onClick={(e) => {
               if (this.mode === 'edit') {
                 e.preventDefault()

--- a/packages/components/src/globals/events.ts
+++ b/packages/components/src/globals/events.ts
@@ -1,8 +1,0 @@
-import { Node } from '@stencila/schema'
-
-export type StencilaNodeUpdateEvent = {
-  type: string
-  documentId: string
-  nodeId: string
-  value: Node
-}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -6,3 +6,7 @@ export type { Colors, ThemeColors } from './types'
 export * as FileFormatUtils from './components/editor/languageUtils'
 export { loadFonts } from './utils/fonts'
 export { injectThemeVariables } from './utils/variables'
+export {
+  CodeVisibilityEvent,
+  DiscoverExecutableLanguagesEvent,
+} from './components/code/codeTypes'

--- a/stories/molecules/codeFragment/codeFragment.stories.js
+++ b/stories/molecules/codeFragment/codeFragment.stories.js
@@ -3,13 +3,22 @@ import { html } from 'lit-html'
 export default {
   title: 'Schema Nodes/Code Fragment',
   component: 'stencila-code-fragment',
+  argTypes: {
+    mode: {
+      defaultValue: 'read',
+      control: {
+        type: 'select',
+      },
+      options: ['read', 'edit'],
+    },
+  },
 }
 
-export const codeFragment = () => html`
+export const codeFragment = ({ mode }) => html`
   <div>
     <p>
       <span>Some</span>
-      <stencila-code-fragment>
+      <stencila-code-fragment .mode=${mode}>
         <code slot="text">code</code>
       </stencila-code-fragment>
       <span>in a paragraph.</span>
@@ -18,7 +27,7 @@ export const codeFragment = () => html`
       <span>With a language</span>
       <stencila-code-fragment
         programming-language="python"
-        .readOnly=${true}
+        .mode=${mode}
         itemtype="http://schema.stenci.la/CodeFragment"
       >
         <code slot="text" class="language-python">


### PR DESCRIPTION
Fixes updating of the `executableLanguages` list in the CodeChunk component,
and emits change events fore CodeFragment/CodeChunk components.