### PR TITLE
fix(Editor): Update precedence of keymaps

### DIFF
--- a/packages/components/src/components/editor/editor.tsx
+++ b/packages/components/src/components/editor/editor.tsx
@@ -445,7 +445,7 @@ export class Editor {
       searchConfig({ top: true }),
       highlightSpecialChars(),
       keymap.of([
-        ...defaultKeymap,
+        ...this.keymap,
         ...commentKeymap,
         ...closeBracketsKeymap,
         ...historyKeymap,
@@ -459,7 +459,7 @@ export class Editor {
           key: 'Ctrl-Enter',
           run: this.execute,
         },
-        ...this.keymap,
+        ...defaultKeymap,
       ]),
       this.readOnlyConf.of(EditorView.editable.of(!this.readOnly)),
       codeErrors(),


### PR DESCRIPTION
Keymaps do not override previously defined shortcuts, as such earlier
mappings have higher precedence.